### PR TITLE
Fix use of types from Dict input values

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -120,7 +120,8 @@ function to_vector_of_tuples(input::Dict)
 
     result = []
     for v in input
-        value_array = v.first isa Tuple ? collect(v.first) : [v.first]
+        value_array = []
+        append!(value_array, v.first isa Tuple ? collect(v.first) : [v.first])
         # Value is always singular
         push!(value_array, v.second)
 


### PR DESCRIPTION
The initial array type was constrained to the key type, breaking any test using multiple types per row