### PR TITLE
Create an engine with the given num workers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 RAI = "9c30249a-7e08-11ec-0e99-a323e937e79f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Adding a function to create an engine representing a cluster with a given set of workers and a given git commit. The latter becomes useful to integrate the project with github actions and run automated tests on branches under development. 

I'm actually copying the same logic from the [BWA script](https://github.com/RelationalAI/basic-workloads-benchmarks/blob/f147a95cccda263db684f7399db1afea62a46ebf/src/engines.jl#L75), which adds some extra features. One is transient storage, it ensures that objects (pages) created by an engine in the cloud will be automatically deleted after a week of inactivity. 