### PR TITLE
Bump RAI version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Arrow = "2"
-RAI = "0.2"
+RAI = "0.2.2"
 julia = "1.8.2"
 
 [extras]

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -487,15 +487,13 @@ function _test_rel_step(
         try
             if !isempty(step.install)
                 if step.install isa Dict
-                    for i in step.install
-                        load_model(get_context(), schema, engine,
-                        Dict(i.first => i.second))
-                    end
+                    load_models(get_context(), schema, engine, step.install)
                 else
+                    models = Dict{String, String}()
                     for i in enumerate(step.install)
-                        load_model(get_context(), schema, engine,
-                        Dict("test_install" * string(i[1]) => i[2]))
+                        models["test_install" * string(i[1])] = i[2]
                     end
+                    load_models(get_context(), schema, engine, models)
                 end
             end
 


### PR DESCRIPTION
Version 0.2.2 of the SDK breaks load_model, instead using a v2-based load_models. Rewrite to match and bump required RAI version.