### PR TITLE
Add method to set context

### DIFF
--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -6,6 +6,7 @@ export test_rel, @test_rel, @testset
 export Step
 export ConcurrentTestSet
 export destroy_test_engines, resize_test_engine_pool, provision_all_test_engines, add_test_engine!
+export set_context
 export set_engine_name_provider, set_engine_name_releaser
 
 include("testsets.jl")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -6,6 +6,9 @@ using Random: MersenneTwister
 using Test
 using UUIDs
 
+mutable struct ContextWrapper
+    context::Context
+end
 
 # Generates a name for the given base name that makes it unique between multiple
 # processing units
@@ -13,10 +16,14 @@ function gen_safe_name(basename)
     return "$(basename)-p$(getpid())-t$(Base.Threads.threadid())-$(UUIDs.uuid4(MersenneTwister()))"
 end
 
-context::Context = Context(load_config())
+TEST_CONTEXT_WRAPPER::ContextWrapper = ContextWrapper(Context(load_config()))
 
 function get_context()::Context
-    return context
+    return TEST_CONTEXT_WRAPPER.context
+end
+
+function set_context(new_context::Context)
+    TEST_CONTEXT_WRAPPER.context = new_context
 end
 
 function create_test_database(clone_db::Union{Nothing,String} = nothing)::String


### PR DESCRIPTION
The context is currently read from the default config file. Adding a setter makes it easier to construct the context and pass it to the testing environment.