### PR TITLE
Add parameter engine

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -252,6 +252,8 @@ constraints have any compilation errors, then the test will still fail (unless
   results), then `broken` can be used to mark the tests as broken and prevent the test from
   failing.
 
+- `engine::String` (optional): the name of an existing engine where tests will be executed
+
 """
 function test_rel(;
     query::Union{String, Nothing} = nothing,
@@ -270,6 +272,7 @@ function test_rel(;
     expect_abort::Bool = false,
     broken::Bool = false,
     clone_db::Union{String, Nothing} = nothing,
+    engine::Union{String, Nothing} = nothing,
 )
     query !== nothing && insert!(steps, 1, Step(
         query = query,
@@ -303,6 +306,7 @@ function test_rel(;
         debug = debug,
         debug_trace = debug_trace,
         clone_db = clone_db,
+        engine = engine,
     )
 end
 
@@ -339,6 +343,8 @@ constraints have any compilation errors, then the test will still fail (unless
 
 - `debug_trace::Bool`: boolean that specifies printing out the debug_trace
 
+- `engine::String` (optional): the name of an existing engine where tests will be executed
+
 """
 function test_rel_steps(;
     steps::Vector{Step},
@@ -348,7 +354,8 @@ function test_rel_steps(;
     abort_on_error::Bool = false,
     debug::Bool = false,
     debug_trace::Bool = false,
-    clone_db::Union{String, Nothing} = nothing
+    clone_db::Union{String, Nothing} = nothing,
+    engine::Union{String, Nothing} = nothing,
 )
     # Setup steps that run before the first testing Step
     config_query = ""
@@ -382,7 +389,8 @@ function test_rel_steps(;
             location = location,
             debug = debug,
             quiet = true,
-            clone_db = clone_db
+            clone_db = clone_db,
+            user_engine = engine,
         )
         add_test_ref(parent, ref)
     else
@@ -392,6 +400,7 @@ function test_rel_steps(;
             location = location,
             debug = debug,
             clone_db = clone_db,
+            user_engine = engine,
         )
     end
 end
@@ -404,6 +413,7 @@ function _test_rel_steps(;
     debug::Bool = false,
     quiet::Bool = false,
     clone_db::Union{String, Nothing} = nothing,
+    user_engine::Union{String, Nothing} = nothing,
 )
     if isnothing(name)
         name = ""
@@ -418,7 +428,7 @@ function _test_rel_steps(;
         name *= resolved_location
     end
 
-    test_engine = get_test_engine()
+    test_engine = user_engine === nothing ? get_test_engine() : user_engine
     debug && println(name, " using test engine: ", test_engine)
     schema = create_test_database(clone_db)
 
@@ -447,7 +457,7 @@ function _test_rel_steps(;
         catch
             println("Could not delete test database: ", schema)
         end
-        release_test_engine(test_engine)
+        user_engine === nothing && release_test_engine(test_engine)
 
     end
 end


### PR DESCRIPTION
This PR adds an additional formal argument `engine` to the testrel function, specifying the name of an existing engine where the tests should be executed. Currently, before this PR, engines should be created/released by the global `TEST_ENGINE_PROVISION` and testrel expects to own the lifecycle of the engine creation/release.

Within the Query Evaluation tests, engines are initialized & released outside the testrel framework. This happens because of custom parameters (e.g. cluster size) and because data is loaded in the database before using the testrel. The PR enables the usage of the engine previously created by the test script. 
While an alternative solution to this PR would be to hook up the global `TEST_ENGINE_PROVISION` from testrel, that would add a certain amount of boilerplate just to specify an existing engine.