### PR TITLE
Add configurable timeout for test execution

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -523,7 +523,7 @@ function _test_rel_step(
                 return nothing
             end
 
-            response = _execute_test(name, get_context(), schema, engine, program)
+            response = _execute_test(name, get_context(), schema, engine, program, step.timeout_sec)
 
             state = response.transaction.state
 


### PR DESCRIPTION
Add configurable timeout for test execution.

Initially this will have a high default value of 30 minutes to avoid immediate conflicts with existing use.