### PR TITLE
Configure global db basename with ENV

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -27,10 +27,7 @@ function set_context(new_context::Context)
 end
 
 function create_test_database(clone_db::Union{Nothing, String} = nothing)::String
-    basename = "test_rel"
-    if haskey(ENV, "TEST_REL_DB_BASENAME")
-        basename = ENV["TEST_REL_DB_BASENAME"]
-    end
+    basename = get(ENV, "TEST_REL_DB_BASENAME", "test_rel")
 
     schema = gen_safe_name(basename)
 


### PR DESCRIPTION
This PR makes two changes to the database naming strategy
- the default base name is changed from `julia-sdk-test` to `test_rel` to better distinguish from the julia sdk tests.
- the base name can be changed using an environment variable. This is most useful when running a set of tests.

Databases are deleted as soon as the test is complete so usually the name is not important, but it may sometimes be useful for debugging.