### PR TITLE
Extend optional debug logging

### DIFF
--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -80,7 +80,7 @@ function replace_engine(name::String)
     try
         delete_engine(get_context(), name)
     catch
-        println("Could not delete engine: ", name)
+        @warn("Could not delete engine: ", name)
         name = TEST_ENGINE_POOL.generator(TEST_ENGINE_POOL.next_id)
     end
 
@@ -154,7 +154,7 @@ function resize_test_engine_pool(size::Int64, generator::Function = get_next_eng
         end
         Threads.@sync for engine in engines
             if length(engines) > size
-                println("Deleting engine ", engine.first)
+                @info("Deleting engine", engine.first)
                 @async try
                     delete_engine(get_context(), engine.first)
                 catch

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -252,7 +252,8 @@ function test_rel(;
     engine::Union{String, Nothing} = nothing,
 )
     if debug
-        ENV["JULIA_DEBUG"] = string(ENV["JULIA_DEBUG"]) * ",RAITest"
+        original_value = haskey(ENV, "Julia_DEBUG") ? string(ENV["JULIA_DEBUG"]) : ""
+        ENV["JULIA_DEBUG"] = original_value * ",RAITest"
     end
 
     query !== nothing && insert!(

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -54,7 +54,7 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
 
     for e in expected
         name = string(e.first)
-        debug && println("looking for expected result for " * name)
+        @debug("looking for expected result for relation " * name)
         if e.first isa Symbol
             name = "/:"
             if !is_special_symbol(e.first)
@@ -74,14 +74,14 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
         # Empty results will not be in the output so check for non-presence
         if isempty(expected_result_tuple_vector)
             if haskey(results, name)
-                println("Expected empty " * name * " not empty")
+                @info("Expected empty " * name * " not empty")
                 return false
             end
             continue
         end
         if !haskey(results, name)
-            println("Expected relation ", name, " not found")
-            debug && @info("results", results)
+            @info("Expected relation ", name, " not found")
+            @debug("All Results", results)
             return false
         end
 
@@ -92,10 +92,8 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
         actual_result = results[name]
         actual_result_vector = sort(collect(zip(actual_result...)))
 
-        if debug
-            @info("expected", expected_result_tuple_vector)
-            @info("actual", actual_result_vector)
-        end
+        @debug("expected", expected_result_tuple_vector)
+        @debug("actual", actual_result_vector)
         !isequal(expected_result_tuple_vector, actual_result_vector) && return false
     end
 
@@ -253,6 +251,10 @@ function test_rel(;
     clone_db::Union{String, Nothing} = nothing,
     engine::Union{String, Nothing} = nothing,
 )
+    if debug
+        ENV["JULIA_DEBUG"] = string(ENV["JULIA_DEBUG"]) * ",RAITest"
+    end
+
     query !== nothing && insert!(
         steps,
         1,
@@ -277,7 +279,7 @@ function test_rel(;
         insert!(steps, 1, Step(; inputs = inputs))
     end
 
-    return test_rel_steps(;
+    result = test_rel_steps(;
         steps = steps,
         name = name,
         location = location,
@@ -288,6 +290,13 @@ function test_rel(;
         clone_db = clone_db,
         engine = engine,
     )
+
+    # Restore the environment if we changed it
+    if debug
+        ENV["JULIA_DEBUG"] = SubString(ENV["JULIA_DEBUG"], 1, lastindex(ENV["JULIA_DEBUG"]) - 8)
+    end
+
+    return result
 end
 
 """
@@ -398,7 +407,7 @@ function _test_rel_steps(;
     end
 
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
-    debug && println(name, " using test engine: ", test_engine)
+    @debug("$name: using test engine: $test_engine")
     schema = create_test_database(clone_db)
 
     try
@@ -409,14 +418,15 @@ function _test_rel_steps(;
                     _test_rel_step(index, step, schema, test_engine, name, length(steps), debug)
                 end
             end
-            println(name, ": time", elapsed_time)
+            stats = (time = elapsed_time.time, allocations = elapsed_time.gcstats.poolalloc, bytes = elapsed_time.gcstats.allocd)
+            @info("$name: $stats")
         end
     finally
         # If database deletion fails
         try
             delete_test_database(schema)
         catch
-            println("Could not delete test database: ", schema)
+            @warn("Could not delete test database: ", schema)
         end
         user_engine === nothing && release_test_engine(test_engine)
     end
@@ -466,9 +476,10 @@ function _execute_test(
     engine::String,
     program::String,
     timeout_sec::Int64)
+    @debug("$name: Starting execution")
     transactionResponse = exec_async(context, schema, engine, program)
     txn_id = transactionResponse.transaction.id
-    @info("Executing $name with txn $txn_id")
+    @info("$name: Executing with txn $txn_id")
 
     # The response may already contain the result. If so, we can return it immediately
     if !isnothing(transactionResponse.results)
@@ -511,10 +522,11 @@ function _test_rel_step(
     #TODO: Remove this when the incoming tests are appropriately rewritten
     program *= generate_output_string_from_expected(step.expected)
 
-    debug && println(">>>>\n", program, "\n<<<<")
+    @debug("$name: generated program", program)
     step_postfix = steps_length > 1 ? " - step$index" : ""
+    name = "$(string(name))$step_postfix"
 
-    @testset BreakableTestSet "$(string(name))$step_postfix" broken = step.broken begin
+    @testset BreakableTestSet "$name" broken = step.broken begin
         try
             if !isempty(step.install)
                 load_models(get_context(), schema, engine, step.install)
@@ -551,12 +563,12 @@ function _test_rel_step(
             # Check if there were any unexpected errors/exceptions
             for problem in problems
                 if contains_problem(step.expected_problems, problem)
-                    debug && @info("Expected problem", problem)
+                    @debug("$name: Expected problem", problem)
                 else
                     unexpected_errors_found |= problem[:severity] == "error"
                     unexpected_errors_found |= problem[:severity] == "exception"
-                    println(name, " - Unexpected: ", problem[:code])
-                    debug && @info("Unexpected problem", problem)
+                    @info("$name: Unexpected problem: ", problem[:code])
+                    @debug("$name: Unexpected problem", problem)
                 end
             end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -92,8 +92,7 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
         actual_result = results[name]
         actual_result_vector = sort(collect(zip(actual_result...)))
 
-        @debug("Expected result", expected_result_tuple_vector)
-        @debug("Actual result", actual_result_vector)
+        @debug("Expected result vs. actual", expected_result_tuple_vector, actual_result_vector)
         !isequal(expected_result_tuple_vector, actual_result_vector) && return false
     end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -92,8 +92,8 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
         actual_result = results[name]
         actual_result_vector = sort(collect(zip(actual_result...)))
 
-        @debug(expected_result_tuple_vector)
-        @debug(actual_result_vector)
+        @debug("Expected result", expected_result_tuple_vector)
+        @debug("Actual result", actual_result_vector)
         !isequal(expected_result_tuple_vector, actual_result_vector) && return false
     end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -542,7 +542,7 @@ function _test_rel_step(
             response = _execute_test(name, get_context(), schema, engine, program, step.timeout_sec)
 
             state = response.transaction.state
-
+            @debug("Response state:", state)
             results = response.results
 
             results_dict = result_table_to_dict(results)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -567,7 +567,7 @@ function _test_rel_step(
                 else
                     unexpected_errors_found |= problem[:severity] == "error"
                     unexpected_errors_found |= problem[:severity] == "exception"
-                    @info("$name: Unexpected problem: ", problem[:code])
+                    @info("$name: Unexpected problem: ${problem[:code]}")
                     @debug("$name: Unexpected problem", problem)
                 end
             end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -567,7 +567,7 @@ function _test_rel_step(
                 else
                     unexpected_errors_found |= problem[:severity] == "error"
                     unexpected_errors_found |= problem[:severity] == "exception"
-                    @info("$name: Unexpected problem: ${problem[:code]}")
+                    @info("$name: Unexpected problem: $(problem[:code])")
                     @debug("$name: Unexpected problem", problem)
                 end
             end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -250,11 +250,6 @@ function test_rel(;
     clone_db::Union{String, Nothing} = nothing,
     engine::Union{String, Nothing} = nothing,
 )
-    if debug
-        # Keep any existing debug settings
-        ENV["JULIA_DEBUG"] = get(ENV, "JULIA_DEBUG", "") * ",RAITest"
-    end
-
     query !== nothing && insert!(
         steps,
         1,
@@ -279,25 +274,24 @@ function test_rel(;
         insert!(steps, 1, Step(; inputs = inputs))
     end
 
-    result = test_rel_steps(;
-        steps = steps,
-        name = name,
-        location = location,
-        include_stdlib = include_stdlib,
-        abort_on_error = abort_on_error,
-        debug = debug,
-        debug_trace = debug_trace,
-        clone_db = clone_db,
-        engine = engine,
-    )
-
-    # Restore the environment if we changed it
+    debug_env = get(ENV, "JULIA_DEBUG", "")
     if debug
-        # Remove the suffix ",RAITest"
-        ENV["JULIA_DEBUG"] = SubString(ENV["JULIA_DEBUG"], 1, lastindex(ENV["JULIA_DEBUG"]) - 8)
+        debug_env = debug_env * ",RAITest"
     end
 
-    return result
+    return withenv("JULIA_DEBUG" => debug_env) do
+        test_rel_steps(;
+            steps = steps,
+            name = name,
+            location = location,
+            include_stdlib = include_stdlib,
+            abort_on_error = abort_on_error,
+            debug = debug,
+            debug_trace = debug_trace,
+            clone_db = clone_db,
+            engine = engine,
+        )
+    end
 end
 
 """

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -30,7 +30,6 @@ function create_test_database(clone_db::Union{Nothing, String} = nothing)::Strin
     basename = get(ENV, "TEST_REL_DB_BASENAME", "test_rel")
     schema = gen_safe_name(basename)
 
-    @debug("Using database name $schema")
     return create_database(get_context(), schema; source = clone_db).database.name
 end
 
@@ -404,7 +403,7 @@ function _test_rel_steps(;
 
     # Database creation can fail, so create database before claiming an engine
     schema = create_test_database(clone_db)
-
+    @debug("$name: Using database name $schema")
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
     @debug("$name: using test engine: $test_engine")
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -252,8 +252,8 @@ function test_rel(;
     engine::Union{String, Nothing} = nothing,
 )
     if debug
-        original_value = haskey(ENV, "Julia_DEBUG") ? string(ENV["JULIA_DEBUG"]) : ""
-        ENV["JULIA_DEBUG"] = original_value * ",RAITest"
+        # Keep any existing debug settings
+        ENV["JULIA_DEBUG"] = get(ENV, "JULIA_DEBUG", "") * ",RAITest"
     end
 
     query !== nothing && insert!(
@@ -294,6 +294,7 @@ function test_rel(;
 
     # Restore the environment if we changed it
     if debug
+        # Remove the suffix ",RAITest"
         ENV["JULIA_DEBUG"] = SubString(ENV["JULIA_DEBUG"], 1, lastindex(ENV["JULIA_DEBUG"]) - 8)
     end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -92,8 +92,8 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
         actual_result = results[name]
         actual_result_vector = sort(collect(zip(actual_result...)))
 
-        @debug("expected", expected_result_tuple_vector)
-        @debug("actual", actual_result_vector)
+        @debug(expected_result_tuple_vector)
+        @debug(actual_result_vector)
         !isequal(expected_result_tuple_vector, actual_result_vector) && return false
     end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -80,7 +80,7 @@ function test_expected(expected::AbstractDict, results, debug::Bool = false)
             continue
         end
         if !haskey(results, name)
-            @info("Expected relation ", name, " not found")
+            @info("Expected relation $name not found")
             @debug("All Results", results)
             return false
         end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -28,9 +28,9 @@ end
 
 function create_test_database(clone_db::Union{Nothing, String} = nothing)::String
     basename = get(ENV, "TEST_REL_DB_BASENAME", "test_rel")
-
     schema = gen_safe_name(basename)
 
+    @debug("Using database name $schema")
     return create_database(get_context(), schema; source = clone_db).database.name
 end
 


### PR DESCRIPTION
The debug level logging is too verbose in general, but can be particularly useful when the test environment is also suspect. Debug mode can be triggered via standard julia tools, such as starting with `JULIA_DEBUG="RAITest" julia`, or by using `debug = true` in the `@test_rel` call.

All test output now uses `@debug` or `@info`. 

An example of the extended logging produced:
```
julia> @test_rel(query="def output = input", inputs=Dict(:input => [2]), expected=Dict(:output => [2]), debug=true)
┌ Debug: REPL[18]:1: using test engine: julia-sdk-test-0
└ @ RAITest ~/src/testrel.jl:412
┌ Debug: Using database name test_rel_test-p38060-d72bc88e-9f64-4dfb-ac18-254ecee9ad52
└ @ RAITest ~/src/testrel.jl:33
┌ Debug: REPL[18]:1: generated program
│   program = "def insert:rel:config:debug = \"basic\"\n"
└ @ RAITest ~/src/testrel.jl:527
┌ Debug: REPL[18]:1 - step1: Starting execution
└ @ RAITest ~/src/testrel.jl:481
[ Info: REPL[18]:1 - step1: Executing with txn d7856640-79a2-1d9d-ba25-07450d91bfb0
┌ Debug: Response state:
│   state = "COMPLETED"
└ @ RAITest ~/src/testrel.jl:545
┌ Debug: REPL[18]:1: generated program
│   program = "\ndef insert:input = (2,)"
└ @ RAITest ~/src/testrel.jl:527
┌ Debug: REPL[18]:1 - step2: Starting execution
└ @ RAITest ~/src/testrel.jl:481
[ Info: REPL[18]:1 - step2: Executing with txn b3bd20f8-a70f-d324-14fc-b1557c036618
┌ Debug: Response state:
│   state = "COMPLETED"
└ @ RAITest ~/src/testrel.jl:545
┌ Debug: REPL[18]:1: generated program
│   program = "def output = input"
└ @ RAITest ~/src/testrel.jl:527
┌ Debug: REPL[18]:1 - step3: Starting execution
└ @ RAITest ~/src/testrel.jl:481
[ Info: REPL[18]:1 - step3: Executing with txn f55b4eab-dfd1-3df7-aba3-678f4a0ade1c
┌ Debug: Response state:
│   state = "COMPLETED"
└ @ RAITest ~/src/testrel.jl:545
┌ Debug: looking for expected result for relation output
└ @ RAITest ~/src/testrel.jl:57
┌ Debug: Expected result
│   expected_result_tuple_vector =
│    1-element Vector{Any}:
│     (2,)
└ @ RAITest ~/src/testrel.jl:95
┌ Debug: Actual result
│   actual_result_vector =
│    1-element Vector{Tuple{Int64}}:
│     (2,)
└ @ RAITest ~/src/testrel.jl:96
[ Info: REPL[18]:1: (time = 21.44619825, allocations = 15343309, bytes = 811228097)
```