### PR TITLE
Exit from db errors before claiming engine

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -398,6 +398,7 @@ function _test_rel_steps(;
     end
 
 
+    # Database creation can fail, so create database before claiming an engine
     schema = create_test_database(clone_db)
 
     test_engine = user_engine === nothing ? get_test_engine() : user_engine


### PR DESCRIPTION
With the existing ordering, a failure when creating a database will cause test_rel to exit before an engine from the testpool is released. That would prevent the engine from being used in any later tests. If enough database errors occurred this could prevent progress. This PR is to move the database creation to before engines are claimed.