### PR TITLE
Create test databases when needed

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -26,8 +26,8 @@ function set_context(new_context::Context)
     return TEST_CONTEXT_WRAPPER.context = new_context
 end
 
-function create_test_database_name()::String
-    basename = get(ENV, "TEST_REL_DB_BASENAME", "test_rel")
+function create_test_database_name(; default_basename="test_rel")::String
+    basename = get(ENV, "TEST_REL_DB_BASENAME", default_basename)
     return gen_safe_name(basename)
 end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -31,8 +31,8 @@ function create_test_database_name(; default_basename="test_rel")::String
     return gen_safe_name(basename)
 end
 
-function create_test_database(name::String, clone_db::Union{Nothing, String} = nothing)::String
-    return create_database(get_context(), name; source = clone_db).database.name
+function create_test_database(name::String, clone_db::Union{Nothing, String} = nothing)
+    create_database(get_context(), name; source = clone_db).database
 end
 
 function delete_test_database(name::String)
@@ -410,7 +410,7 @@ function _test_rel_steps(;
     try
         type = quiet ? QuietTestSet : Test.DefaultTestSet
         @testset type "$(string(name))" begin
-            schema = create_test_database(schema, clone_db)
+            create_test_database(schema, clone_db)
             elapsed_time = @timed begin
                 for (index, step) in enumerate(steps)
                     _test_rel_step(index, step, schema, test_engine, name, length(steps))

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -26,11 +26,13 @@ function set_context(new_context::Context)
     return TEST_CONTEXT_WRAPPER.context = new_context
 end
 
-function create_test_database(clone_db::Union{Nothing, String} = nothing)::String
+function create_test_database_name()::String
     basename = get(ENV, "TEST_REL_DB_BASENAME", "test_rel")
-    schema = gen_safe_name(basename)
+    return gen_safe_name(basename)
+end
 
-    return create_database(get_context(), schema; source = clone_db).database.name
+function create_test_database(name::String, clone_db::Union{Nothing, String} = nothing)::String
+    return create_database(get_context(), name; source = clone_db).database.name
 end
 
 function delete_test_database(name::String)
@@ -398,15 +400,17 @@ function _test_rel_steps(;
     end
 
 
-    # Database creation can fail, so create database before claiming an engine
-    schema = create_test_database(clone_db)
+    # Generate a name for the test database
+    schema = create_test_database_name()
     @debug("$name: Using database name $schema")
+
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
     @debug("$name: using test engine: $test_engine")
 
     try
         type = quiet ? QuietTestSet : Test.DefaultTestSet
         @testset type "$(string(name))" begin
+            schema = create_test_database(schema, clone_db)
             elapsed_time = @timed begin
                 for (index, step) in enumerate(steps)
                     _test_rel_step(index, step, schema, test_engine, name, length(steps))
@@ -416,7 +420,6 @@ function _test_rel_steps(;
             @info("$name: $stats")
         end
     finally
-        # If database deletion fails
         try
             delete_test_database(schema)
         catch

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -13,7 +13,7 @@ end
 # Generates a name for the given base name that makes it unique between multiple
 # processing units
 function gen_safe_name(basename)
-    return "$(basename)-p$(getpid())-$(UUIDs.uuid4(MersenneTwister()))"
+    return "$(basename)-$(UUIDs.uuid4(MersenneTwister()))"
 end
 
 TEST_CONTEXT_WRAPPER::ContextWrapper = ContextWrapper(Context(load_config()))


### PR DESCRIPTION
Currently the databases are created before the engine is requested. When using the testpool, the engine request is used to limit the number of parallel engine uses. This means that a database for every test in a testset is created at the start of testing and only deleted after each test. If testing terminates early those databases may be left behind.

This PR is to rearrange the database creation so that it is only created when needed, and removed when the test finishes. While the db naming is being modified, I took the opportunity to simplify the naming - this is useful as db name length is limited.