### PR TITLE
Simplify engine deletion thread use

### DIFF
--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -163,9 +163,11 @@ function resize_test_engine_pool(size::Int64, generator::Function = get_next_eng
         Threads.@sync for engine in engines_to_delete
             @info("Deleting engine", engine)
             @async try
-                delete_engine(get_context(), engine.first)
-            catch
+                delete_engine(get_context(), engine)
+            catch e
                 # The engine may not exist if it hasn't been used yet
+                # For other errors, we just report the error and delete what we can
+                @info(e)
             end
         end
     end

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -156,9 +156,8 @@ function resize_test_engine_pool(size::Int64, generator::Function = get_next_eng
         # Move the first length - size engines to the list of engines to delete
         engines_to_delete = String[]
         while length(engines) > size
-            engine_name = first(engines).first
+            engine_name, _ = pop!(engines)
             push!(engines_to_delete, engine_name)
-            delete!(engines, engine_name)
         end
         # Asynchronously delete the engines
         Threads.@sync for engine in engines_to_delete


### PR DESCRIPTION
Refactor testpool deletion with safer deletion of engines. The existing approach has a potential for non-threadsafe use of keys.