### PR TITLE
Limit the length of generated names to fit db name length

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -12,8 +12,12 @@ end
 
 # Generates a name for the given base name that makes it unique between multiple
 # processing units
+# Generated names are truncated at 63 characters. This limit is reached when the
+# base name is 28 characters long. Longer base names can be used but uniqueness
+# is not guaranteed
 function gen_safe_name(basename)
-    return "$(basename)-$(UUIDs.uuid4(MersenneTwister()))"
+    name = "$(basename)-$(UUIDs.uuid4(MersenneTwister()))"
+    return name[1:min(sizeof(name), 63)]
 end
 
 TEST_CONTEXT_WRAPPER::ContextWrapper = ContextWrapper(Context(load_config()))


### PR DESCRIPTION
Database names have a limited length of 63 characters. This PR is to limit our name generation to fit that limit by truncating generated names. If the name, pre-truncation, is over 63 characters then the 'uniqueness' of the UUID is reduced.

The result of generating non-unique names, such as if a base name with length > 63 is used, would be the failure of concurrent tests with database creation errors. This error case has a low penalty, with ample warning.