### PR TITLE
Escape '$' string inputs in rel-specific manner

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -30,17 +30,41 @@ function convert_input_dict_to_string(inputs::AbstractDict)
                 program *= "; "
             end
 
-            if i isa String
-                program *= '"' * i * '"'
-            elseif i isa Char
-                program *= "'" * i * "'"
-            else
-                program *= string(i)
-            end
+            program *= input_element_to_string(i)
         end
     end
     return program
 end
+
+function input_element_to_string(input)
+    return repr(input)
+end
+
+# Escape strings in a format that is valid rel
+function input_element_to_string(input::String)
+    return "\"" * escape_string(input) * "\""
+end
+
+function input_element_to_string(input::Tuple)
+    if length(input) == 0
+        return "()"
+    end
+
+    if length(input) == 1
+        return input_element_to_string(input...)
+    end
+
+
+    program = "("
+    for element in input
+        program *= input_element_to_string(element)
+        program *= ","
+    end
+    program *= ")"
+
+    return program
+end
+
 
 # Extract relation names from the expected output and append them to output
 # Turns a dict of name=>vector, with names of form :othername/Type

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -57,10 +57,7 @@ function input_element_to_string(input::Tuple)
 
 
     program = "("
-    for element in input
-        program *= input_element_to_string(element)
-        program *= ","
-    end
+    program *= join(input_element_to_string.(input), ",")
     program *= ")"
 
     return program

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -41,6 +41,7 @@ function input_element_to_string(input)
 end
 
 # Escape strings in a format that is valid rel
+# repr() would be nice, but does not produce valid rel-escaped strings
 function input_element_to_string(input::String)
     return "\"" * escape_string(input) * "\""
 end


### PR DESCRIPTION
Currently input arguments are translated from julia to rel using `string(tuple)`. This generally provides the translations needed (uint -> 0x00, etc), but strings containing `$` will be escaped which is valid for julia, but not rel. Using `string()` in this way does seem to be a bit quirky - `repr()` is closer to what is desired, but is still not rel-specific This PR is to provide rel-specific translations.

It's worth noting that a better approach for tests would be to provide input from within rel, or for large inputs via csv/json.