### PR TITLE
Add timeout arguments to HTTP requests

### DIFF
--- a/src/engines.jl
+++ b/src/engines.jl
@@ -13,7 +13,7 @@ function _wait_till_provisioned(engine_name, max_wait_time_s = 240)
     # Current provisioning time is ~60s
     time_delta_s = 1
 
-    response = get_engine(get_context(), engine_name)
+    response = get_engine(get_context(), engine_name; readtimeout = max_wait_time_s)
 
     # The engine exists - now we wait until it is not in the provisioning stage
     while (response.state != "PROVISIONED")
@@ -25,7 +25,7 @@ function _wait_till_provisioned(engine_name, max_wait_time_s = 240)
         end
 
         sleep(time_delta_s)
-        response = get_engine(get_context(), engine_name)
+        response = get_engine(get_context(), engine_name; readtimeout = max_wait_time_s)
     end
 
     return response.name
@@ -41,7 +41,7 @@ function create_default_engine(name::String)
     max_wait_time_s = 120
 
     try
-        get_engine(get_context(), name)
+        get_engine(get_context(), name; readtimeout = max_wait_time_s)
         # The engine already exists so return it immediately
         return name
     catch
@@ -49,7 +49,7 @@ function create_default_engine(name::String)
     end
 
     # Request engine creation
-    create_engine(get_context(), name; size = size)
+    create_engine(get_context(), name; size = size, readtimeout = max_wait_time_s)
 
     # Wait for engine to be provisioned
     return _wait_till_provisioned(name, max_wait_time_s)


### PR DESCRIPTION
This PR is to add a read timeout to HTTP requests.

I've used the existing test timeout as an upper bound. These timeouts are extremely generous for initiating an HTTP request. An arbitrary lower value, such as 10s or 60s might be more appropriate, but since we already have the overall timeout I used that.

The read timeout is also applied by the HTTP package to connection timeouts, but that doesn't seem to be documented so could conceivably change. The code is more readable without the currently redundant connection timeout so I went for readability.