### PR TITLE
Even more protective timeouts

### DIFF
--- a/src/engines.jl
+++ b/src/engines.jl
@@ -7,7 +7,7 @@ mutable struct TestEngineProvision
     creater::Function
 end
 
-function _wait_till_provisioned(engine_name, max_wait_time_s = 240)
+function _wait_till_provisioned(engine_name, max_wait_time_s = 600)
     start_time = time()
     # This should be a rare event, so a coarse-grained period is acceptable
     # Current provisioning time is ~60s
@@ -38,7 +38,7 @@ return once the provisioning process is complete, or failed.
 """
 function create_default_engine(name::String)
     size = "XS"
-    max_wait_time_s = 120
+    max_wait_time_s = 600
 
     try
         get_engine(get_context(), name; readtimeout = max_wait_time_s)


### PR DESCRIPTION
There are two timeout changes introduced:
* Engine provisioning timeout increased from 2 minutes to 10 minutes. 10 minutes is a better match for provisioning delays that will eventually succeed.
* get/cancel transaction readtimeouts added  - these are expected to return immediately, with low probability of failures, but the cost of paranoia is extremely low