### PR TITLE
feat: add readonly to `Step` (and refactor to use `Option`)

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -1,3 +1,6 @@
+# helper for optional types
+const Option{T} = Union{Nothing, T}
+
 # Extract relation names from the inputs and adds them to the program
 # Turns a dict of name=>vector, with names of form :othername/Type,
 # into a series of def name = list of tuples

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -9,7 +9,7 @@ function release_pooled_test_engine(name::String)
     end
 end
 
-function get_pooled_test_engine(engine_name::Union{String, Nothing} = nothing)
+function get_pooled_test_engine(engine_name::Option{String} = nothing)
     if isnothing(engine_name)
         engine_name = get_free_test_engine_name()
     end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -481,7 +481,7 @@ function _execute_test(
     engine::String,
     program::String,
     timeout_sec::Int64,
-    readonly::Bool
+    readonly::Bool,
 )
     @debug("$name: Starting execution")
     rsp = exec_async(context, schema, engine, program;

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -148,7 +148,7 @@ struct Step
     expected_problems::Vector
     expect_abort::Bool
     timeout_sec::Int64
-    readonly::Option{Bool}
+    readonly::Bool
 end
 
 function Step(;
@@ -161,7 +161,7 @@ function Step(;
     expected_problems::Vector = Problem[],
     expect_abort::Bool = false,
     timeout_sec::Int64 = 1800,
-    readonly::Option{Bool} = nothing,
+    readonly::Bool = false,
 )
     return Step(
         query,
@@ -516,10 +516,6 @@ function _test_rel_step(
 )
     program = something(step.query, "")
 
-    # If readonly wasn't set, we assume if there are multiple steps, the transaction 
-    # should be write, otherwise, readonly
-    readonly = something(step.readonly, steps_length == 1)
-
     #Append inputs to program
     program *= convert_input_dict_to_string(step.inputs)
 
@@ -544,7 +540,7 @@ function _test_rel_step(
                 return nothing
             end
 
-            response = _execute_test(name, get_context(), schema, engine, program, step.timeout_sec, readonly)
+            response = _execute_test(name, get_context(), schema, engine, program, step.timeout_sec, step.readonly)
 
             state = response.transaction.state
             @debug("Response state:", state)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -35,7 +35,7 @@ function create_test_database_name(; default_basename="test_rel")::String
     return gen_safe_name(basename)
 end
 
-function create_test_database(name::String, clone_db::Union{Nothing, String} = nothing)
+function create_test_database(name::String, clone_db::Option{String} = nothing)
     create_database(get_context(), name; source = clone_db).database
 end
 
@@ -139,7 +139,7 @@ end
       errors. When `expected_problems` is `[]`, this means that errors are allowed.
 """
 struct Step
-    query::Union{String, Nothing}
+    query::Option{String}
     install::Dict{String, String}
     broken::Bool
     schema_inputs::AbstractDict
@@ -148,10 +148,11 @@ struct Step
     expected_problems::Vector
     expect_abort::Bool
     timeout_sec::Int64
+    readonly::Option{Bool}
 end
 
 function Step(;
-    query::Union{String, Nothing} = nothing,
+    query::Option{String} = nothing,
     install::AcceptedSourceTypes = Dict{String, String}(),
     broken::Bool = false,
     schema_inputs::AbstractDict = Dict(),
@@ -160,6 +161,7 @@ function Step(;
     expected_problems::Vector = Problem[],
     expect_abort::Bool = false,
     timeout_sec::Int64 = 1800,
+    readonly::Option{Bool} = nothing,
 )
     return Step(
         query,
@@ -171,6 +173,7 @@ function Step(;
         expected_problems,
         expect_abort,
         timeout_sec,
+        readonly
     )
 end
 
@@ -236,10 +239,10 @@ Note that `test_rel` creates a new schema for each test.
   - `engine::String` (optional): the name of an existing engine where tests will be executed
 """
 function test_rel(;
-    query::Union{String, Nothing} = nothing,
+    query::Option{String} = nothing,
     steps::Vector{Step} = Step[],
-    name::Union{String, Nothing} = nothing,
-    location::Union{LineNumberNode, Nothing} = nothing,
+    name::Option{String} = nothing,
+    location::Option{LineNumberNode} = nothing,
     include_stdlib::Bool = true,
     install::AcceptedSourceTypes = Dict{String, String}(),
     abort_on_error::Bool = false,
@@ -252,8 +255,8 @@ function test_rel(;
     expect_abort::Bool = false,
     timeout_sec::Int64 = 1800,
     broken::Bool = false,
-    clone_db::Union{String, Nothing} = nothing,
-    engine::Union{String, Nothing} = nothing,
+    clone_db::Option{String} = nothing,
+    engine::Option{String} = nothing,
 )
     query !== nothing && insert!(
         steps,
@@ -326,14 +329,14 @@ Note that `test_rel` creates a new schema for each test.
 """
 function test_rel_steps(;
     steps::Vector{Step},
-    name::Union{String, Nothing} = nothing,
-    location::Union{LineNumberNode, Nothing} = nothing,
+    name::Option{String} = nothing,
+    location::Option{LineNumberNode} = nothing,
     include_stdlib::Bool = true,
     abort_on_error::Bool = false,
     debug::Bool = false,
     debug_trace::Bool = false,
-    clone_db::Union{String, Nothing} = nothing,
-    engine::Union{String, Nothing} = nothing,
+    clone_db::Option{String} = nothing,
+    engine::Option{String} = nothing,
 )
     # Setup steps that run before the first testing Step
     config_query = ""
@@ -384,11 +387,11 @@ end
 # This internal function executes `test_rel`
 function _test_rel_steps(;
     steps::Vector{Step},
-    name::Union{String, Nothing},
-    location::Union{LineNumberNode, Nothing},
+    name::Option{String},
+    location::Option{LineNumberNode},
     quiet::Bool = false,
-    clone_db::Union{String, Nothing} = nothing,
-    user_engine::Union{String, Nothing} = nothing,
+    clone_db::Option{String} = nothing,
+    user_engine::Option{String} = nothing,
 )
     if isnothing(name)
         name = ""
@@ -477,16 +480,18 @@ function _execute_test(
     schema::String,
     engine::String,
     program::String,
-    timeout_sec::Int64)
+    timeout_sec::Int64,
+    readonly::Bool
+)
     @debug("$name: Starting execution")
-    transactionResponse = exec_async(context, schema, engine, program;
-            readtimeout = timeout_sec)
-    txn_id = transactionResponse.transaction.id
+    rsp = exec_async(context, schema, engine, program;
+            readtimeout = timeout_sec, readonly)
+    txn_id = rsp.transaction.id
     @info("$name: Executing with txn $txn_id")
 
     # The response may already contain the result. If so, we can return it immediately
-    if !isnothing(transactionResponse.results)
-        return transactionResponse
+    if !isnothing(rsp.results)
+        return rsp
     end
     # The transaction was not immediately completed.
     # Poll until the transaction is done, or times out, then return the results.
@@ -509,11 +514,11 @@ function _test_rel_step(
     name::String,
     steps_length::Int,
 )
-    if !isnothing(step.query)
-        program = step.query
-    else
-        program = ""
-    end
+    program = something(step.query, "")
+
+    # If readonly wasn't set, we assume if there are multiple steps, the transaction 
+    # should be write, otherwise, readonly
+    readonly = something(step.readonly, steps_length == 1)
 
     #Append inputs to program
     program *= convert_input_dict_to_string(step.inputs)
@@ -539,7 +544,7 @@ function _test_rel_step(
                 return nothing
             end
 
-            response = _execute_test(name, get_context(), schema, engine, program, step.timeout_sec)
+            response = _execute_test(name, get_context(), schema, engine, program, step.timeout_sec, readonly)
 
             state = response.transaction.state
             @debug("Response state:", state)


### PR DESCRIPTION
Add the ability to set the `readonly` status of a `Step`, which maps to a transaction. A step test is assumed to be write unless passed `reaadonly = true`.

Other:
* Introduced the `Option{T}` type and put it to use as I wanted it for the `readonly`.
* renamed `transactionResponse` to `rsp` to avoid the 🐫 