### PR TITLE
Separate tests for completion status and unexpected errors

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -591,7 +591,7 @@ function _test_rel_step(
                 @test state == "COMPLETED"
                 @test !unexpected_errors_found
                 if state == "ABORTED"
-                    @info("Abort reason", response.transaction.abort_reason)
+                    @info("$name: Transaction $(response.transaction.id) aborted due to $(response.transaction.abort_reason)")
                 end
             else
                 @test state == "ABORTED"

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -590,7 +590,7 @@ function _test_rel_step(
             if !step.expect_abort
                 @test state == "COMPLETED"
                 @test !unexpected_errors_found
-                if state != "COMPLETED"
+                if state == "ABORTED"
                     @info("Abort reason", response.transaction.abort_reason)
                 end
             else

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -588,7 +588,11 @@ function _test_rel_step(
             end
 
             if !step.expect_abort
-                @test state == "COMPLETED" && !unexpected_errors_found
+                @test state == "COMPLETED"
+                @test !unexpected_errors_found
+                if state != "COMPLETED"
+                    @info("Abort reason", response.transaction.abort_reason)
+                end
             else
                 @test state == "ABORTED"
             end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -591,7 +591,7 @@ function _test_rel_step(
                 @test state == "COMPLETED"
                 @test !unexpected_errors_found
                 if state == "ABORTED"
-                    @info("$name: Transaction $(response.transaction.id) aborted due to $(response.transaction.abort_reason)")
+                    @info("$name: Transaction $(response.transaction.id) aborted due to \"$(response.transaction.abort_reason)\"")
                 end
             else
                 @test state == "ABORTED"


### PR DESCRIPTION
Split `@test`s for successful finish of a test that is expected to successfully finish into a test for completion state and a separate test for unexpected errors.

If the test was aborted show the given reason.