### PR TITLE
Capture logs, print them all if it failed, otherwise, just a summary

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 RAI = "9c30249a-7e08-11ec-0e99-a323e937e79f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -1,6 +1,6 @@
 module RAITest
 
-using Test: @testset
+using Test: @testset, TestLogger, LogRecord
 
 import Logging
 

--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -2,6 +2,8 @@ module RAITest
 
 using Test: @testset
 
+import Logging
+
 export test_rel, @test_rel, @testset
 export Problem, Step
 export ConcurrentTestSet

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -264,8 +264,8 @@ function result_table_to_dict(results)
 end
 
 # Log a captured log via the current logger
-function playback_log((;level, message, _module, group, id, file, line, kwargs)::LogRecord)
-    cur_logger = Logging.current_logger()
-    Logging.handle_message(cur_logger, level, message, _module, group, id, file, line; kwargs...)
+function playback_log(io::IO, (;level, message, _module, group, id, file, line, kwargs)::LogRecord)
+    logger = Logging.ConsoleLogger(io)
+    Logging.handle_message(logger, level, message, _module, group, id, file, line; kwargs...)
     return nothing
 end

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -262,3 +262,10 @@ function result_table_to_dict(results)
     end
     return dict_results
 end
+
+# Log a captured log via the current logger
+function playback_log((;level, message, _module, group, id, file, line, kwargs)::LogRecord)
+    cur_logger = Logging.current_logger()
+    Logging.handle_message(cur_logger, level, message, _module, group, id, file, line; kwargs...)
+    return nothing
+end

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -274,12 +274,11 @@ end
 function get_logging_io()
     io = IOBuffer()
 
+    stream = stderr
     logger = Logging.current_logger()
-    color = if hasproperty(logger, :stream)
-        get(logger.stream, :color, false)
-    else
-        get(stderr, :color, false)
+    if hasproperty(logger, :stream) && isopen(logger.stream)
+        stream = logger.stream
     end
-    ctx = IOContext(io, :color => color)
+    ctx = IOContext(io, stream)
     return io, ctx
 end

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -269,3 +269,17 @@ function playback_log(io::IO, (;level, message, _module, group, id, file, line, 
     Logging.handle_message(logger, level, message, _module, group, id, file, line; kwargs...)
     return nothing
 end
+
+# Get an io and ctx that are colored according to the current logger's capabilities
+function get_logging_io()
+    io = IOBuffer()
+
+    logger = Logging.current_logger()
+    color = if hasproperty(logger, :stream)
+        get(logger.stream, :color, false)
+    else
+        get(stderr, :color, false)
+    end
+    ctx = IOContext(io, :color => color)
+    return io, ctx
+end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -455,9 +455,7 @@ function _test_rel_steps(;
         end
 
         # dump all of the captured logs
-        redirect_stdio(stdout=ctx, stderr=ctx) do
-            playback_log.(logger.logs)
-        end
+        playback_log.(logger.logs)
         Base.show(ctx, e)
         msg = String(take!(io))
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -419,8 +419,8 @@ function _test_rel_steps(;
     try
         type = quiet ? QuietTestSet : Test.DefaultTestSet
         duration = nothing
-        ts = Logging.with_logger(logger) do 
-            @testset type "$(string(name))" begin
+        ts = @testset type "$(string(name))" begin
+            Logging.with_logger(logger) do
                 create_test_database(schema, clone_db)
                 stats = @timed begin
                     for (index, step) in enumerate(steps)
@@ -442,14 +442,14 @@ function _test_rel_steps(;
             write(ctx, "[ERROR] $name\n\n CAPTURED LOGS:\n")
             playback_log.(ctx, logger.logs)
             msg = String(take!(io))
-            @error msg database=schema engine_name=test_engine test_name=name
+            @error msg database=schema engine_name=test_engine test_name=name duration
         elseif anyfail(ts)
             io = IOBuffer()
             ctx = IOContext(io, :color => get(stderr, :color, false))
             write(ctx, "[FAIL] $name\n\n CAPTURED LOGS:\n")
             playback_log.(ctx, logger.logs)
             msg = String(take!(io))
-            @warn msg database=schema engine_name=test_engine test_name=name
+            @warn msg database=schema engine_name=test_engine test_name=name duration
         else
             txnids = Set()
             for log in logger.logs

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -449,10 +449,10 @@ function _test_rel_steps(;
             if anyfail(ts)
                 write(ctx, "[FAIL]")
             end
-            write(ctx, " $name\n\n CAPTURED LOGS:\n")
+            write(ctx, " $name duration=$duration\n\n CAPTURED LOGS:\n")
             playback_log.(ctx, logger.logs)
             msg = String(take!(io))
-            @error msg database=schema engine_name=test_engine test_name=name duration
+            @error msg database=schema engine_name=test_engine
         else
             txnids = Set()
             for log in logger.logs

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -465,6 +465,8 @@ function _test_rel_steps(;
             end
             msg = String(take!(io))
             @error msg database=schema engine_name=test_engine test_name=name passed=nothing
+        end
+        
         try
             delete_test_database(schema)
         catch

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -428,11 +428,6 @@ function _test_rel_steps(;
                 create_test_database(schema, clone_db)
                 for (index, step) in enumerate(steps)
                     _test_rel_step(index, step, schema, test_engine, name, length(steps))
-                    if index % 4 == 0
-                        @test index == 1
-                    elseif index % 5 == 0
-                        throw("UH OH")
-                    end
                 end
             end
         end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -443,21 +443,19 @@ function _test_rel_steps(;
             msg = String(take!(io))
             @warn msg database=schema engine_name=test_engine test_name=name passed=false duration
         else
-            io = IOBuffer()
-            write(io, "Test $name passed\n\n Transaction IDs used:\n")
             txnids = Set()
             for log in logger.logs
-                if haskey(log.kwargs, "transaction_id")
-                    push!(txnids, log.kwargs["transaction_id"])
+                if haskey(log.kwargs, :transaction_id)
+                    push!(txnids, log.kwargs[:transaction_id])
                 end
             end
-            write(io, join(txnids, "\n"))
-            msg = String(take!(io))
+            msg = """Test $name passed TxIDs=[$(join(txnids, ", "))]""" 
             @info msg database=schema engine_name=test_engine test_name=name passed=true duration
         end
         logged = true
     finally
         if !logged
+            @error "here, uh oh"
             io = IOBuffer()
             write(io, "Something went wrong running test $name \n\n CAPTURED LOGS:\n")
             redirect_stdio(stdout=io, stderr=io) do

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -453,6 +453,7 @@ function _test_rel_steps(;
             @info msg database=schema engine_name=test_engine test_name=name passed=true duration
         end
         logged = true
+        return ts
     finally
         if !logged
             @error "here, uh oh"

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -426,13 +426,12 @@ function _test_rel_steps(;
                 stats = @timed begin
                     for (index, step) in enumerate(steps)
                         _test_rel_step(index, step, schema, test_engine, name, length(steps))
+                        if index % 4 == 0
+                            @test index == 1
+                        elseif index % 5 == 0
+                            throw("UH OH")
+                        end
                     end
-                end
-                if rand(1:10) == 7
-                    @test false
-                end
-                if rand(1:10) == 9
-                    throw("UH OH")
                 end
                 duration = sprint(show, stats.time; context=:compact => true)
             end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -425,8 +425,8 @@ function _test_rel_steps(;
     try
         type = QuietTestSet
         duration = nothing
-        ts = @testset type "$(string(name))" begin
-            Logging.with_logger(logger) do
+        ts = Logging.with_logger(logger) do
+            @testset type "$(string(name))" begin
                 create_test_database(schema, clone_db)
                 stats = @timed begin
                     for (index, step) in enumerate(steps)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -441,7 +441,7 @@ function _test_rel_steps(;
         # Print summary of logs from the testset, or all logs if it did not pass
         if anynonpass(ts)
             # dump all of the captured logs
-            io = IOBuffer(;context=:color => get(logger.stream, :color, false))
+            io = IOBuffer(;context=:color => get(stderr, :color, false))
             write(io, "[FAIL] $name\n\n CAPTURED LOGS:\n")
             redirect_stdio(stdout=io, stderr=io) do
                 playback_log.(logger.logs)
@@ -461,7 +461,7 @@ function _test_rel_steps(;
         return ts
     finally
         if !logged
-            io = IOBuffer(;context=:color => get(logger.stream, :color, false))
+            io = IOBuffer(;context=:color => get(stderr, :color, false))
             write(io, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")
             redirect_stdio(stdout=io, stderr=io) do
                 playback_log.(logger.logs)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -466,7 +466,7 @@ function _test_rel_steps(;
             msg = String(take!(io))
             @error msg database=schema engine_name=test_engine test_name=name passed=nothing
         end
-        
+
         try
             delete_test_database(schema)
         catch
@@ -529,7 +529,7 @@ function _execute_test(
     rsp = exec_async(context, schema, engine, program;
             readtimeout = timeout_sec, readonly)
     txn_id = rsp.transaction.id
-    @info("$name: Executing with txn $txn_id"; transaction_id=txn_id)
+    @info "$name: Executing with txn $txn_id" transaction_id=txn_id
 
     # The response may already contain the result. If so, we can return it immediately
     if !isnothing(rsp.results)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -455,7 +455,7 @@ function _test_rel_steps(;
         end
 
         # dump all of the captured logs
-        playback_log.(logger.logs)
+        playback_log.(ctx, logger.logs)
         Base.show(ctx, e)
         msg = String(take!(io))
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -374,7 +374,7 @@ function test_rel_steps(;
             steps = steps,
             name = name,
             location = location,
-            quiet = true,
+            nested = true,
             clone_db = clone_db,
             user_engine = engine,
         )
@@ -395,7 +395,7 @@ function _test_rel_steps(;
     steps::Vector{Step},
     name::Option{String},
     location::Option{LineNumberNode},
-    quiet::Bool = false,
+    nested::Bool = false,
     clone_db::Option{String} = nothing,
     user_engine::Option{String} = nothing,
 )
@@ -423,10 +423,9 @@ function _test_rel_steps(;
     logger = TestLogger()
 
     try
-        type = QuietTestSet
         duration = nothing
         ts = Logging.with_logger(logger) do
-            @testset type "$(string(name))" begin
+            @testset TestRelTestSet nested=nested "$(string(name))" begin
                 create_test_database(schema, clone_db)
                 stats = @timed begin
                     for (index, step) in enumerate(steps)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -423,12 +423,12 @@ function _test_rel_steps(;
         ts = Logging.with_logger(logger) do 
             @testset type "$(string(name))" begin
                 create_test_database(schema, clone_db)
-                @timed begin
+                stats = @timed begin
                     for (index, step) in enumerate(steps)
                         _test_rel_step(index, step, schema, test_engine, name, length(steps))
                     end
                 end
-                duration = elapsed_time.time
+                duration = stats.time
             end
         end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -436,7 +436,14 @@ function _test_rel_steps(;
             end
         end
 
-        if anynonpass(ts)
+        if anyerror(ts)
+            io = IOBuffer()
+            ctx = IOContext(io, :color => get(stderr, :color, false))
+            write(ctx, "[ERROR] $name\n\n CAPTURED LOGS:\n")
+            playback_log.(ctx, logger.logs)
+            msg = String(take!(io))
+            @error msg database=schema engine_name=test_engine test_name=name
+        elseif anyfail(ts)
             io = IOBuffer()
             ctx = IOContext(io, :color => get(stderr, :color, false))
             write(ctx, "[FAIL] $name\n\n CAPTURED LOGS:\n")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -417,7 +417,7 @@ function _test_rel_steps(;
     logger = TestLogger()
 
     try
-        type = quiet ? QuietTestSet : Test.DefaultTestSet
+        type = QuietTestSet
         duration = nothing
         ts = @testset type "$(string(name))" begin
             Logging.with_logger(logger) do
@@ -461,14 +461,14 @@ function _test_rel_steps(;
         end
 
         ts
-    catch e
+    catch err
         io = IOBuffer()
         ctx = IOContext(io, :color => get(stderr, :color, false))
         write(ctx, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")
 
         # dump all of the captured logs
         playback_log.(ctx, logger.logs)
-        Base.show(ctx, e)
+        Base.show(ctx, err)
         msg = String(take!(io))
 
         @error msg database=schema engine_name=test_engine test_name=name

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -443,6 +443,8 @@ function _test_rel_steps(;
             end
         end
         @info """[PASS] $name duration=$duration TxIDs=[$(join(txnids, ", "))]""" 
+
+        ts
     catch e
         io = IOBuffer()
         ctx = IOContext(io, :color => get(stderr, :color, false))

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -423,23 +423,21 @@ function _test_rel_steps(;
     logger = TestLogger()
 
     try
-        duration = nothing
-        ts = Logging.with_logger(logger) do
+        stats = @timed Logging.with_logger(logger) do
             @testset TestRelTestSet nested=nested "$(string(name))" begin
                 create_test_database(schema, clone_db)
-                stats = @timed begin
-                    for (index, step) in enumerate(steps)
-                        _test_rel_step(index, step, schema, test_engine, name, length(steps))
-                        if index % 4 == 0
-                            @test index == 1
-                        elseif index % 5 == 0
-                            throw("UH OH")
-                        end
+                for (index, step) in enumerate(steps)
+                    _test_rel_step(index, step, schema, test_engine, name, length(steps))
+                    if index % 4 == 0
+                        @test index == 1
+                    elseif index % 5 == 0
+                        throw("UH OH")
                     end
                 end
-                duration = sprint(show, stats.time; context=:compact => true)
             end
         end
+        duration = sprint(show, stats.time; context=:compact => true)
+        ts = stats.value
 
         if anyerror(ts) || anyfail(ts)
             io, ctx = get_logging_io()

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -97,8 +97,14 @@ function test_expected(expected::AbstractDict, results, testname::String)
         actual_result = results[name]
         actual_result_vector = sort(collect(zip(actual_result...)))
 
-        @debug("$testname: Expected result vs. actual", expected_result_tuple_vector, actual_result_vector)
-        !isequal(expected_result_tuple_vector, actual_result_vector) && return false
+        
+        if !isequal(expected_result_tuple_vector, actual_result_vector)
+            @info("$testname: Expected result vs. actual", expected_result_tuple_vector, actual_result_vector)
+            return false
+        else
+            @debug("$testname: Expected result vs. actual", expected_result_tuple_vector, actual_result_vector)
+            return true
+        end
     end
 
     return true

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -57,8 +57,7 @@ record(ts::QuietTestSet, res::Test.Result) = record(ts.dts, res)
 
 # log these - by default they get printed to stdout
 function record(ts::QuietTestSet, t::Union{Test.Fail, Test.Error})
-    io = IOBuffer()
-    ctx = IOContext(io, :color => get(stderr, :color, false))
+    io, ctx = get_logging_io()
     print(ctx, ts.dts.description, ": ")
     print(ctx, t)
     msg = String(take!(io))

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -62,12 +62,7 @@ function record(ts::QuietTestSet, t::Union{Test.Fail, Test.Error})
     print(ctx, ts.dts.description, ": ")
     print(ctx, t)
     msg = String(take!(io))
-
-    if t isa Test.Fail 
-        @warn msg
-    else
-        @error msg
-    end
+    @error msg
 
     push!(ts.dts.results, t)
     return t

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -64,6 +64,9 @@ function finish(ts::QuietTestSet)
     return ts.dts
 end
 
+anynonpass(ts::QuietTestSet) = anynonpass(ts.dts)
+anynonpass(ts::Test.DefaultTestSet) = ts.anynonpass
+
 # TestSet that can be marked as broken.
 # This allows the broken status to be applied to a group of tests.
 mutable struct BreakableTestSet <: Test.AbstractTestSet

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -64,8 +64,17 @@ function finish(ts::QuietTestSet)
     return ts.dts
 end
 
-anynonpass(ts::QuietTestSet) = anynonpass(ts.dts)
-anynonpass(ts::Test.DefaultTestSet) = ts.anynonpass
+anyerror(ts::QuietTestSet) = anyerror(ts.dts)
+function anyerror(ts::Test.DefaultTestSet)
+    stats = Test.get_test_counts(ts)
+    return stats[3] + stats[7] > 0
+end
+
+anyfail(ts::QuietTestSet) = anyfail(ts.dts)
+function anyfail(ts::Test.DefaultTestSet)
+    stats = Test.get_test_counts(ts)
+    return stats[2] + stats[6] > 0
+end
 
 # TestSet that can be marked as broken.
 # This allows the broken status to be applied to a group of tests.

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -44,19 +44,21 @@ function add_test_ref(testset::AbstractTestSet, test_ref)
     return fetch(test_ref)
 end
 
-# Wrap a DefaultTestSet. Results are recorded, but not printed.
-# This is helpful when used with a separate environment
-mutable struct QuietTestSet <: AbstractTestSet
+# Wrap a DefaultTestSet. Results are recorded, but not printed if nested=true.
+# This is helpful when used in a ConcurrentTestSet where the parent
+# linkage is lost due to the concurrency
+mutable struct TestRelTestSet
     dts::Test.DefaultTestSet
+    nested::Bool
 
-    QuietTestSet(desc) = new(Test.DefaultTestSet(desc))
+    TestRelTestSet(desc; nested=false) = new(Test.DefaultTestSet(desc), nested)
 end
 
-record(ts::QuietTestSet, child::AbstractTestSet) = record(ts.dts, child)
-record(ts::QuietTestSet, res::Test.Result) = record(ts.dts, res)
+record(ts::TestRelTestSet, child::AbstractTestSet) = record(ts.dts, child)
+record(ts::TestRelTestSet, res::Test.Result) = record(ts.dts, res)
 
 # log these - by default they get printed to stdout
-function record(ts::QuietTestSet, t::Union{Test.Fail, Test.Error})
+function record(ts::TestRelTestSet, t::Union{Test.Fail, Test.Error})
     io, ctx = get_logging_io()
     print(ctx, ts.dts.description, ": ")
     print(ctx, t)
@@ -67,22 +69,24 @@ function record(ts::QuietTestSet, t::Union{Test.Fail, Test.Error})
     return t
 end
 
-function finish(ts::QuietTestSet)
+function finish(ts::TestRelTestSet)
     if Test.get_testset_depth() > 0
         # Attach this test set to the parent test set
         parent_ts = Test.get_testset()
         record(parent_ts, ts.dts)
+        return ts
     end
+    !ts.nested && finish(ts.dts)
     return ts.dts
 end
 
-anyerror(ts::QuietTestSet) = anyerror(ts.dts)
+anyerror(ts::TestRelTestSet) = anyerror(ts.dts)
 function anyerror(ts::Test.DefaultTestSet)
     stats = Test.get_test_counts(ts)
     return stats[3] + stats[7] > 0
 end
 
-anyfail(ts::QuietTestSet) = anyfail(ts.dts)
+anyfail(ts::TestRelTestSet) = anyfail(ts.dts)
 function anyfail(ts::Test.DefaultTestSet)
     stats = Test.get_test_counts(ts)
     return stats[2] + stats[6] > 0

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -55,15 +55,12 @@ end
 record(ts::QuietTestSet, child::AbstractTestSet) = record(ts.dts, child)
 record(ts::QuietTestSet, res::Test.Result) = record(ts.dts, res)
 
+# log these - by default they get printed to stdout
 function record(ts::QuietTestSet, t::Union{Test.Fail, Test.Error})
     io = IOBuffer()
     ctx = IOContext(io, :color => get(stderr, :color, false))
-    print(ctx, ts.description, ": ")
+    print(ctx, ts.dts.description, ": ")
     print(ctx, t)
-    if !isa(t, Error) # if not gets printed in the show method
-        Base.show_backtrace(ctx, scrub_backtrace(backtrace()))
-    end
-    println(ctx)
     msg = String(take!(io))
 
     if t isa Test.Fail 

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -47,7 +47,7 @@ end
 # Wrap a DefaultTestSet. Results are recorded, but not printed if nested=true.
 # This is helpful when used in a ConcurrentTestSet where the parent
 # linkage is lost due to the concurrency
-mutable struct TestRelTestSet
+mutable struct TestRelTestSet <: AbstractTestSet
     dts::Test.DefaultTestSet
     nested::Bool
 


### PR DESCRIPTION
Capture logs while running a `@test_rel` generated test set. If the test passes, just print a summary info. If it does not pass, bundle and log all of the captured logs along with metadata.

Example output: https://github.com/RelationalAI/raicode/actions/runs/4915893587/jobs/8779111254

Questions:
- What is `QuietTestSet`? I've hijacked it a bit and am not sure what the implications are here.