### PR TITLE
fix: unexpected passes, reporting all the things, checking all the things

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -338,7 +338,7 @@ function test_rel_steps(;
     location::Option{LineNumberNode} = nothing,
     include_stdlib::Bool = true,
     abort_on_error::Bool = false,
-    debug::Bool = false,
+    debug::Bool = true,
     debug_trace::Bool = false,
     clone_db::Option{String} = nothing,
     engine::Option{String} = nothing,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -259,7 +259,7 @@ function test_rel(;
     expected_problems::Vector = Problem[],
     expect_abort::Bool = false,
     timeout_sec::Int64 = 1800,
-    broken::Bool = true,
+    broken::Bool = false,
     clone_db::Option{String} = nothing,
     engine::Option{String} = nothing,
 )

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -103,7 +103,6 @@ function test_expected(expected::AbstractDict, results, testname::String)
             return false
         else
             @debug("$testname: Expected result vs. actual", expected_result_tuple_vector, actual_result_vector)
-            return true
         end
     end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -590,6 +590,8 @@ function _test_rel_step(
             for expected_problem in step.expected_problems
                 expected_problem_found = contains_problem(problems, expected_problem)
                 @test expected_problem_found
+                @test 1 == 2
+                throw("uh oh")
             end
 
             # PASS:

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -420,7 +420,7 @@ function _test_rel_steps(;
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
     @debug("$name: using test engine: $test_engine")
 
-    logger = TestLogger()
+    logger = TestLogger(; catch_exceptions=true)
 
     try
         stats = @timed Logging.with_logger(logger) do

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -589,7 +589,6 @@ function _test_rel_step(
         for expected_problem in step.expected_problems
             expected_problem_found = contains_problem(problems, expected_problem)
             @test expected_problem_found
-            throw("uh oh")
         end
 
         # PASS:

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -590,8 +590,6 @@ function _test_rel_step(
             for expected_problem in step.expected_problems
                 expected_problem_found = contains_problem(problems, expected_problem)
                 @test expected_problem_found
-                @test 1 == 2
-                throw("uh oh")
             end
 
             # PASS:

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -370,22 +370,16 @@ function test_rel_steps(;
     parent = Test.get_testset()
     if parent isa ConcurrentTestSet
         ref = Threads.@spawn _test_rel_steps(;
-            steps = steps,
-            name = name,
-            location = location,
-            nested = true,
-            clone_db = clone_db,
-            user_engine = engine,
+            steps,
+            name,
+            location,
+            nested=true,
+            clone_db,
+            user_engine=engine,
         )
         add_test_ref(parent, ref)
     else
-        _test_rel_steps(;
-            steps = steps,
-            name = name,
-            location = location,
-            clone_db = clone_db,
-            user_engine = engine,
-        )
+        _test_rel_steps(; steps, name, location, clone_db, user_engine=engine)
     end
 end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -259,7 +259,7 @@ function test_rel(;
     expected_problems::Vector = Problem[],
     expect_abort::Bool = false,
     timeout_sec::Int64 = 1800,
-    broken::Bool = false,
+    broken::Bool = true,
     clone_db::Option{String} = nothing,
     engine::Option{String} = nothing,
 )
@@ -338,7 +338,7 @@ function test_rel_steps(;
     location::Option{LineNumberNode} = nothing,
     include_stdlib::Bool = true,
     abort_on_error::Bool = false,
-    debug::Bool = true,
+    debug::Bool = false,
     debug_trace::Bool = false,
     clone_db::Option{String} = nothing,
     engine::Option{String} = nothing,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -572,7 +572,7 @@ function _test_rel_step(
     step_postfix = steps_length > 1 ? " - step$index" : ""
     name = "$(string(name))$step_postfix"
 
-    @testset BreakableTestSet "$name" broken = step.broken begin
+    @testset TestRelTestSet "$name" broken = step.broken begin
         try
             if !isempty(step.install)
                 load_models(get_context(), schema, engine, step.install)

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -86,10 +86,13 @@ function finish(ts::TestRelTestSet)
         ts.dts.n_passed = 0
         empty!(ts.dts.results)
 
+        # Default unbroken message doesn't make sense for @test_rel
+        @error """Unexpected pass
+        Got correct result: $(ts.dts.description) 
+        Please remove `broken` flag if no longer broken.
+        """
         t = Test.Error(:test_unbroken, ts.dts.description, "", "", LineNumberNode(0))
         push!(ts.dts.results, t)
-        log_test_error(ts, t)
-        @info "I'm unbroken" ts
     end
 
     if Test.get_testset_depth() > 0

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -19,8 +19,7 @@ record(ts::ConcurrentTestSet, res::Test.Result) = record(ts.dts, res)
 # If this is the parent then show results
 function finish(ts::ConcurrentTestSet)
     for t in ts.tests
-        f = fetch(t)
-        record(ts.dts, f)
+        record(ts.dts, fetch(t))
     end
     if Test.get_testset_depth() > 0
         # Attach this test set to the parent test set

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -107,7 +107,7 @@ function record(ts::BreakableTestSet, t::Union{Test.Fail, Test.Error})
         push!(ts.dts.results, Test.Broken(t.test_type, t.orig_expr))
     else
         log_test_error(t)
-        record(ts.dts, t)
+        push!(ts.dts.results, t)
     end
 end
 

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -52,7 +52,7 @@ end
 mutable struct TestRelTestSet <: AbstractTestSet
     dts::Test.DefaultTestSet
     nested::Bool
-    broken::Bool
+    broken_expected::Bool
     broken_found::Bool
 
     TestRelTestSet(desc; nested=false, broken=false) = 
@@ -65,7 +65,7 @@ record(ts::TestRelTestSet, res::Test.Result) = record(ts.dts, res)
 
 # Flip to broken if expected, if not, log them (recording to dts goes to stdout)
 function record(ts::TestRelTestSet, t::Union{Test.Fail, Test.Error})
-    if ts.broken
+    if ts.broken_expected
         ts.broken_found = true
         push!(ts.dts.results, Test.Broken(t.test_type, t.orig_expr))
     else
@@ -76,7 +76,7 @@ function record(ts::TestRelTestSet, t::Union{Test.Fail, Test.Error})
 end
 
 function finish(ts::TestRelTestSet)
-    if ts.broken && !ts.broken_found
+    if ts.broken_expected && !ts.broken_found
         # If we expect broken tests and everything passes, drop the results and 
         # replace with an unbroken Error
         ts.dts.n_passed = 0

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -63,7 +63,8 @@ record(ts::TestRelTestSet, child::AbstractTestSet) = record(ts.dts, child)
 record(ts::Test.DefaultTestSet, child::TestRelTestSet) = record(ts, child.dts)
 record(ts::TestRelTestSet, res::Test.Result) = record(ts.dts, res)
 
-# Flip to broken if expected, if not, log them (recording to dts goes to stdout)
+# Change error/fail to broken if expected and record as such. If not expected, 
+# log the failure and record the result.
 function record(ts::TestRelTestSet, t::Union{Test.Fail, Test.Error})
     if ts.broken_expected
         ts.broken_found = true

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -110,6 +110,7 @@ record(ts::BreakableTestSet, res::Test.Result) = record(ts.dts, res)
 function record(ts::BreakableTestSet, t::Union{Test.Fail, Test.Error})
     if ts.broken
         ts.broken_found = true
+        @info "I broke" t
         push!(ts.dts.results, Test.Broken(t.test_type, t.orig_expr))
     else
         record(ts.dts, t)
@@ -127,6 +128,7 @@ function finish(ts::BreakableTestSet)
             ts.dts.results,
             Test.Error(:test_unbroken, ts.dts.description, "", "", LineNumberNode(0)),
         )
+        @info "I'm unbroken" ts
     end
     if Test.get_testset_depth() > 0
         # Attach this test set to the parent test set


### PR DESCRIPTION
A few follow on fixes/changes from #42 
* The unexpected pass message was no longer printing - fix that and make the message make sense for test rel
  * <img width="631" alt="image" src="https://github.com/RelationalAI/rai-test-julia/assets/24885580/91f314d0-8512-45f4-b672-2308d6c5162e">
* The expected results check was exiting early - don't do that
* Consolidate `BreakableTestSet` into `TestRelTestSet` to reduce maintenance surface area

Here's an example of the current logging: https://github.com/RelationalAI/raicode/actions/runs/4949324840/jobs/8851504265 (ignore the debugs, that's just on locally)
And another one with the double error fixed: https://github.com/RelationalAI/raicode/actions/runs/4949562495/jobs/8852098227
