### PR TITLE
Add `X-Request-ID` to requests before we have a transaction ID

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -554,6 +554,7 @@ function _execute_test(
         # Exec async really should return after 2-3 seconds
         headers = ["X-Request-ID" => request_id]
         exec_async(context, schema, engine, program; readtimeout=30, readonly, headers)
+        throw("uh oh")
     catch e
         @error "$name: Failed to submit transaction\n\n$e" retry_number submit_failed = true request_id
         if retry_number < 3

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -623,7 +623,7 @@ function _test_rel_step(
 
         # Don't test empty strings
         if program == ""
-            return nothing
+            @goto end_of_test
         end
 
         response = _execute_test(
@@ -696,5 +696,7 @@ function _test_rel_step(
         else
             @test state == "ABORTED"
         end
+        
+        @label end_of_test
     end
 end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -434,7 +434,7 @@ function _test_rel_steps(;
                     inner_ts = _test_rel_step(index, step, schema, test_engine, name, length(steps))
                     # short circuit if something errored
                     if anyerror(inner_ts) && index < length(steps)
-                        @error "Error running $name - not executing further steps"
+                        @error "Terminal error running $name - not executing further steps"
                         break
                     end
                 end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -554,7 +554,6 @@ function _execute_test(
         # Exec async really should return after 2-3 seconds
         headers = ["X-Request-ID" => request_id]
         exec_async(context, schema, engine, program; readtimeout=30, readonly, headers)
-        throw("uh oh")
     catch e
         @error "$name: Failed to submit transaction\n\n$e" retry_number submit_failed = true request_id
         if retry_number < 3

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -535,12 +535,14 @@ function _execute_test(
     readonly::Bool;
     retry_number=1,
 )
-    @debug("$name: Starting execution")
+    request_id = string(UUIDs.uuid4())
+    @debug("$name: Starting execution ReqId=$request_id")
     rsp = try
         # Exec async really should return after 2-3 seconds
-        exec_async(context, schema, engine, program; readtimeout=30, readonly)
+        headers = ["X-Request-ID" => request_id]
+        exec_async(context, schema, engine, program; readtimeout=30, readonly, headers)
     catch e
-        @error "$name: Failed to submit transaction\n\n$e" retry_number submit_failed=true
+        @error "$name: Failed to submit transaction\n\n$e" retry_number submit_failed=true request_id
         if retry_number < 3
             # Try again
             return _execute_test(

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -420,7 +420,7 @@ function _test_rel_steps(;
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
     @debug("$name: using test engine: $test_engine")
 
-    logger = TestLogger()
+    logger = TestLogger(; catch_exceptions=true)
 
     try
         stats = @timed Logging.with_logger(logger) do

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -422,7 +422,10 @@ function _test_rel_steps(;
                 for (index, step) in enumerate(steps)
                     inner_ts = _test_rel_step(index, step, schema, test_engine, name, length(steps))
                     # short circuit if something errored
-                    anyerror(inner_ts) && break
+                    if anyerror(inner_ts) && index < length(steps)
+                        @error "Error running $name - not executing further steps"
+                        break
+                    end
                 end
             end
         end
@@ -548,7 +551,6 @@ function _execute_test(
         # Exec async really should return after 2-3 seconds
         headers = ["X-Request-ID" => request_id]
         exec_async(context, schema, engine, program; readtimeout=30, readonly, headers)
-        throw("uh oh")
     catch e
         @error "$name: Failed to submit transaction\n\n$e" retry_number submit_failed=true request_id
         if retry_number < 3

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -420,7 +420,9 @@ function _test_rel_steps(;
             @testset TestRelTestSet nested=nested "$name" begin
                 create_test_database(schema, clone_db)
                 for (index, step) in enumerate(steps)
-                    _test_rel_step(index, step, schema, test_engine, name, length(steps))
+                    inner_ts = _test_rel_step(index, step, schema, test_engine, name, length(steps))
+                    # short circuit if something errored
+                    anyerror(inner_ts) && break
                 end
             end
         end


### PR DESCRIPTION
Make sure we can trace the request to infra.

RAICode test branch: https://github.com/RelationalAI/raicode/pull/13681