### PR TITLE
Set level of allowable problems

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -643,12 +643,16 @@ function _test_rel_step(
 
         unexpected_errors_found = false
         error_levels = []
-        if step.allow_unexpected == :warning
+        # Exceptions are always unexpected
+        if step.allow_unexpected == :error
+            push!(error_levels, "exception")
+        else if step.allow_unexpected == :warning
             push!(error_levels, "error")
             push!(error_levels, "exception")
-        end
-        if step.allow_unexpected == :none
+        else if step.allow_unexpected == :none
             push!(error_levels, "warning")
+            push!(error_levels, "error")
+            push!(error_levels, "exception")
         end
 
         # Check if there were any unexpected errors/exceptions

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -231,6 +231,8 @@ Note that `test_rel` creates a new schema for each test.
   - `expected_problems::Vector`: expected problems. The semantics of
     `expected_problems` is that the program must contain a super set of the specified
     error codes.
+  - `allow_unexpected::Symbol`: ignore problems with severity equal or lower than
+    specified. Accepted values are `:none`, `:warning`, `:error`.
   - `include_stdlib::Bool`: boolean that specifies whether to include the stdlib
   - `install::Dict{String, String}`: source files to install in the database.
   - `schema_inputs::AbstractDict`: input schema for the transaction

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -263,6 +263,7 @@ function test_rel(;
     broken::Bool=false,
     clone_db::Option{String}=nothing,
     engine::Option{String}=nothing,
+    kwargs...
 )
     query !== nothing && insert!(
         steps,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -644,7 +644,7 @@ function _test_rel_step(
         #   Unexpected problems with severity worse than allowable are not found
 
         unexpected_errors_found = false
-        error_levels = Set{Symbol}()
+        error_levels = Set()
         # Exceptions are always unexpected
         if step.allow_unexpected == :error
             push!(error_levels, "exception")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -644,7 +644,7 @@ function _test_rel_step(
         #   Unexpected problems with severity worse than allowable are not found
 
         unexpected_errors_found = false
-        error_levels = []
+        error_levels = Set{Symbol}()
         # Exceptions are always unexpected
         if step.allow_unexpected == :error
             push!(error_levels, "exception")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -648,10 +648,10 @@ function _test_rel_step(
         # Exceptions are always unexpected
         if step.allow_unexpected == :error
             push!(error_levels, "exception")
-        else if step.allow_unexpected == :warning
+        elseif step.allow_unexpected == :warning
             push!(error_levels, "error")
             push!(error_levels, "exception")
-        else if step.allow_unexpected == :none
+        elseif step.allow_unexpected == :none
             push!(error_levels, "warning")
             push!(error_levels, "error")
             push!(error_levels, "exception")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -267,7 +267,6 @@ function test_rel(;
     broken::Bool=false,
     clone_db::Option{String}=nothing,
     engine::Option{String}=nothing,
-    kwargs...,
 )
     query !== nothing && insert!(
         steps,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -672,11 +672,6 @@ function _test_rel_step(
             @test test_expected(step.expected, results_dict, name)
         end
 
-        # Allow all errors if any problems were expected
-        if !isempty(step.expected_problems)
-            unexpected_errors_found = false
-        end
-
         if !step.expect_abort
             @test state == "COMPLETED"
             @test !unexpected_errors_found

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -69,7 +69,7 @@ end
 record(ts::RAITestSet, child::AbstractTestSet) = record(ts.dts, child)
 record(ts::Test.DefaultTestSet, child::RAITestSet) = record(ts, child.dts)
 function record(ts::RAITestSet, res::Test.Result)
-    # This is not typical, but if an error gets thrown in the testset, but 
+    # This is not typical, but if an error gets thrown in the testset, but
     # not in a `@test_rel`, we need to record it
     counts = ReTestItems.JUnitCounts()
     counts.tests += res isa Test.Result
@@ -99,7 +99,7 @@ function record(ts::RAITestSet, res::Test.Result)
         junit_record!(suite, tc)
         junit_record!(ts.junit, suite)
     end
-    record(ts.dts, res)
+    return record(ts.dts, res)
 end
 
 # Record any results directly stored and fetch results from any listed concurrent tests
@@ -130,7 +130,7 @@ function finish(ts::RAITestSet)
 end
 
 # Wrap a DefaultTestSet with some behavior specific to @test_rel.
-# 
+#
 # Results are recorded, but not printed if nested=true.
 # This is helpful when used in a RAITestSet where the parent
 # linkage is lost due to the concurrency.
@@ -168,7 +168,7 @@ record(ts::TestRelTestSet, child::AbstractTestSet) = record(ts.dts, child)
 record(ts::Test.DefaultTestSet, child::TestRelTestSet) = record(ts, child.dts)
 record(ts::TestRelTestSet, res::Test.Result) = record(ts.dts, res)
 
-# Change error/fail to broken if expected and record as such. If not expected, 
+# Change error/fail to broken if expected and record as such. If not expected,
 # log the failure and record the result.
 function record(ts::TestRelTestSet, t::Union{Test.Fail, Test.Error})
     if ts.broken_expected
@@ -186,14 +186,14 @@ function finish(ts::TestRelTestSet)
     ts.dts.time_end = time()
 
     if ts.broken_expected && !ts.broken_found
-        # If we expect broken tests and everything passes, drop the results and 
+        # If we expect broken tests and everything passes, drop the results and
         # replace with an unbroken Error
         ts.dts.n_passed = 0
         empty!(ts.dts.results)
 
         # Default unbroken message doesn't make sense for @test_rel
         @error """Unexpected pass
-        Got correct result: $(ts.dts.description) 
+        Got correct result: $(ts.dts.description)
         Please remove `broken` flag if no longer broken.
         """
         t = Test.Error(:test_unbroken, ts.dts.description, "", "", LineNumberNode(0))


### PR DESCRIPTION
Currently test_rel ignores all warning level messages and only fails if an unexpected error was seen, 
This PR is to add a test_rel parameter to set the level of allowable problems (none, warning, error). By default, tests fail if they encounter an unexpected error.

#### Current test_rel:
`expected_problems = []`
ignore warnings and errors

`expected_problems = [X, Y, ...]`
fail if any listed problem is not present
ignore all other warnings and errors

#### New test_rel:
`expected_problems = [X, Y, ...]`
fail if any listed problem is not present
+
`allow_unexpected = :none`
fail on any unexpected warning or error
`allow_unexpected = :warning`
fail on any unexpected error
`allow_unexpected = :error`
ignore all other warnings and errors