### PR TITLE
Distribute test set finishing

### DIFF
--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -108,14 +108,20 @@ function finish(ts::RAITestSet)
     # Record the time manually so it's available for JUnit reporting
     ts.dts.time_end = time()
 
-    for t in ts.distributed_tests
-        record(ts, fetch(t))
-    end
     if Test.get_testset_depth() > 0
         # Attach this test set to the parent test set
         parent_ts = Test.get_testset()
-        record(parent_ts, ts)
+        distribute_test(parent_ts) do
+            for t in ts.distributed_tests
+                record(ts, fetch(t))
+            end
+            return ts
+        end
         return ts
+    end
+
+    for t in ts.distributed_tests
+        record(ts, fetch(t))
     end
 
     # We are the root testet, Write JUnit XML

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -111,6 +111,9 @@ end
 function finish(ts::RAITestSet)
     if Test.get_testset_depth() > 0
         # Attach this test set to the parent test set
+        # If the test set is distrubted, this will push a ref
+        # into the parent test's queue to fetch upon finish.
+        # It allows inter-test set concurrency as opposed to only intra.
         parent_ts = Test.get_testset()
         distribute_test(parent_ts) do
             for t in ts.distributed_tests


### PR DESCRIPTION
Also distribute the nested test sets, so we get more tighly packed concurrency. Currently, each test set runs in serial, this allows them to interleave.

It seems to save about 30 minutes of wall time on the tests.

Test PR: https://github.com/RelationalAI/raicode/pull/13883