### PR TITLE
Add delay before retrying connection

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -545,6 +545,11 @@ function _execute_test(
     catch e
         @error "$name: Failed to submit transaction\n\n$e" retry_number submit_failed = true
         if retry_number < 3
+            # Transactions may have been successfully submitted, even though the connection
+            # failed. Sleep for 30s to give the engine a chance to finish.
+            # This will help simple tests with a briefly flaky connection. Long tests will
+            # not benefit.
+            sleep(30)
             # Try again
             return _execute_test(
                 name,


### PR DESCRIPTION
Retrying a test due to a flaky connection may result in running multiple repeats of the test on a single engine which can cause a different set of problems.

This PR adds a semi-arbitrary 30s wait before retrying which will give shorter transactions a chance to finish (if they exist) and could conceivably give a flaky connection a chance to deflake.

Backing off on each retry would help in some cases, but if you're dealing with a flaky connection and a long, long, test, a quicker failure would be more productive.