### PR TITLE
Strip `file:line` info for the `testcase` name

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -386,7 +386,7 @@ function test_rel_steps(;
     if isnothing(name)
         name = ""
     else
-        name = name * " at "
+        name = name * " @ "  # Use `@` so it's easier to strip this info later.
     end
 
     if !isnothing(location)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -396,15 +396,6 @@ function test_rel_steps(;
         name *= resolved_location
     end
 
-    if is_reportable(parent)
-        # make sure name is unique if reporting on it
-        name_count = get!(parent.name_dict, name, 1)
-        parent.name_dict[name] += 1
-        if name_count > 1
-            name *= " ($name_count)"
-        end
-    end
-
     distribute_test(parent) do
         return _test_rel_steps(; steps, name, nested=is_distributed(parent), clone_db, user_engine=engine)
     end
@@ -702,7 +693,7 @@ function _test_rel_step(
         else
             @test state == "ABORTED"
         end
-        
+
         @label end_of_test
     end
 end

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -174,7 +174,7 @@ const LOCATION_SUFFIX_RE = Regex(" @ \\S*(?!$sep\\S*$sep)\\S*.jl:\\d*\$")
 
 function record(ts::RAITestSet, child::TestRelTestSet)
     # Strip additional `file:line` info, so names are robust to movement in files.
-    name = chopsuffix(child.dts.description, LOCATION_SUFFIX_RE)
+    name = String(chopsuffix(child.dts.description, LOCATION_SUFFIX_RE))
     counts = ReTestItems.JUnitCounts(child.dts)
     # Populate logs if error message is set
     logs = if !isnothing(child.error_message)

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -80,7 +80,9 @@ function record(ts::RAITestSet, res::Test.Result)
     counts.errors += res isa Test.Error
     counts.skipped += res isa Test.Broken
 
-    name = ts.dts.description
+    # Strip additional `file:line` info, so names are robust to movement in files.
+    # This currently relies on `" @ "` not appearing in the `name` of the `@test_rel`.
+    name = chopsuffix(ts.dts.description, r" @ .*")
 
     tc = ReTestItems.JUnitTestCase(name, counts, nothing, nothing, nothing)
 

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -172,9 +172,11 @@ end
 const sep = escape_string(Base.Filesystem.path_separator)
 const LOCATION_SUFFIX_RE = Regex(" @ \\S*(?!$sep\\S*$sep)\\S*.jl:\\d*\$")
 
+# Strip additional `@ file:line` info, so reported names are robust to movement in files.
+strip_location(name::AbstractString) = String(chopsuffix(name, LOCATION_SUFFIX_RE))
+
 function record(ts::RAITestSet, child::TestRelTestSet)
-    # Strip additional `file:line` info, so names are robust to movement in files.
-    name = String(chopsuffix(child.dts.description, LOCATION_SUFFIX_RE))
+    name = strip_location(child.dts.description)
     counts = ReTestItems.JUnitCounts(child.dts)
     # Populate logs if error message is set
     logs = if !isnothing(child.error_message)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ for distributed in (true, false)
     end
 end
 
-@testset "LOCATION_SUFFIX_RE" begin
+@testset "strip_location" begin
     for line in (0, 42, 999)
         for path in (
             "foo-tests.jl",
@@ -38,7 +38,7 @@ end
         )
             for name in ("name", "evil name @ looks/like/a/file.jl:123")
                 @show full_name = "$name @ $path:$line"
-                @test chopsuffix(full_name, RAITest.LOCATION_SUFFIX_RE) == name
+                @test RAITest.strip_location(full_name) == name
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,3 +27,19 @@ for distributed in (true, false)
         @test inner.n_passed == 1
     end
 end
+
+@testset "LOCATION_SUFFIX_RE" begin
+    for line in (0, 42, 999)
+        for path in (
+            "foo-tests.jl",
+            joinpath("bar", "foo.jl"),
+            joinpath("qux", "bar", "foo.jl"),
+            joinpath("test_dir", "qux", "bar", "foo-test.jl"),
+        )
+            for name in ("name", "evil name @ looks/like/a/file.jl:123")
+                @show full_name = "$name @ $path:$line"
+                @test chopsuffix(full_name, RAITest.LOCATION_SUFFIX_RE) == name
+            end
+        end
+    end
+end


### PR DESCRIPTION
If the `@test_rel` has a `name`, then you that name (without the additional `@ file:line` info) in the XML report

This makes (named) tests easier to track over time, as the name in the report is robust to changes in the line location of the test

This also makes the names in the report match those produced by tests run by ReTestItems, once we no longer edit names to be globally unique. In our internal test suite, we already enforce test names in the same file being unique, which is enough to ensure there is no clash in the XML report (given that tests are reported in a different `testsuite` per file)

Part of [RAI-13812](https://relationalai.atlassian.net/browse/RAI-13812)

Testing this at https://github.com/RelationalAI/raicode/pull/14313

[RAI-13812]: https://relationalai.atlassian.net/browse/RAI-13812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ