### PR TITLE
Define and export short-hands for `Step`

### DIFF
--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -7,7 +7,7 @@ import Pkg
 
 export test_rel, @test_rel, @testset
 export RAITestSet
-export Problem, Step
+export Problem, Step, ReadQuery, WriteQuery, Install
 
 export destroy_test_engines
 export resize_test_engine_pool

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -184,6 +184,7 @@ function Step(;
     )
 end
 
+# Helpers for commonly used Steps
 ReadQuery(s::String; kwargs...) = Step(; query=s, readonly=true, kwargs...)
 WriteQuery(s::String; kwargs...) = Step(; query=s, readonly=false, kwargs...)
 Install(x; kwargs...) = Step(; install=x, kwargs...)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -184,6 +184,10 @@ function Step(;
     )
 end
 
+ReadQuery(s::String; kwargs...) = Step(; query=s, readonly=true, kwargs...)
+WriteQuery(s::String; kwargs...) = Step(; query=s, readonly=false, kwargs...)
+Install(x; kwargs...) = Step(; install=x, kwargs...)
+
 """
 The macro `@test_rel` takes a named tuple as an argument and calls the
 `test_rel` function, augmenting the parameters with the location of the macro


### PR DESCRIPTION
These are the helpers that have repeatedly been defined and used internally, so moving them upstream

close https://relationalai.atlassian.net/browse/RAI-13398