### PR TITLE
Record non-distributed test results

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -405,12 +405,8 @@ function test_rel_steps(;
         end
     end
 
-    if is_distributed(parent)
-        distribute_test(parent) do
-            return _test_rel_steps(; steps, name, nested=true, clone_db, user_engine=engine)
-        end
-    else
-        _test_rel_steps(; steps, name, clone_db, user_engine=engine)
+    distribute_test(parent) do
+        return _test_rel_steps(; steps, name, nested=is_distributed(parent), clone_db, user_engine=engine)
     end
 end
 
@@ -706,7 +702,7 @@ function _test_rel_step(
         else
             @test state == "ABORTED"
         end
-        
+
         @label end_of_test
     end
 end


### PR DESCRIPTION
Before:
```julia
julia> @testset RAITestSet report=true distributed=false "outer" begin
           @testset "inner-serial" begin
               @test true
           end
       end
[ Info: Writing JUnit XML file to "/Users/nickr/repos/rai-test-julia/report-RAITest-20230623-164025.xml"
Test Summary: |Time
outer         | None  0.3s
RAITestSet(Test.DefaultTestSet("outer", Any[], 0, false, false, true, 1.687534825446035e9, 1.687534825742785e9), true, false, Task[], ReTestItems.JUnitTestSuites("outer", ReTestItems.JUnitCounts(nothing, 0.0, 0, 0, 0, 0), ReTestItems.JUnitTestSuite[]), Dict("inner-serial" => 2))

shell> head report-RAITest-20230623-164025.xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites timestamp="" time="0.0" tests="0" skipped="0" failures="0" errors="0">
</testsuites>

```

Now:
```julia
julia> @testset RAITestSet report=true distributed=false "outer" begin
           @testset "inner-serial" begin
               @test true
           end
       end
[ Info: Writing JUnit XML file to "/Users/nickr/repos/rai-test-julia/report-RAITest-20230623-163847.xml"
Test Summary: | Pass  Total  Time
outer         |    1      1  0.0s
RAITestSet(Test.DefaultTestSet("outer", Any[Test.DefaultTestSet("inner-serial", Any[], 1, false, false, true, 1.687534727512872e9, 1.687534727512937e9)], 0, false, false, true, 1.687534727512781e9, 1.687534727514298e9), true, false, Task[], Any[RAITestSet(Test.DefaultTestSet("inner-serial", Any[], 1, false, false, true, 1.687534727512872e9, 1.687534727512937e9), true, false, Task[], Any[], ReTestItems.JUnitTestSuite("inner-serial", ReTestItems.JUnitCounts(nothing, 0.0, 1, 0, 0, 0), ReTestItems.JUnitTestCase[ReTestItems.JUnitTestCase("inner-serial", ReTestItems.JUnitCounts(nothing, 0.0, 1, 0, 0, 0), nothing, nothing, nothing)]), Dict("inner-serial" => 2))], ReTestItems.JUnitTestSuites("outer", ReTestItems.JUnitCounts(nothing, 0.0, 1, 0, 0, 0), ReTestItems.JUnitTestSuite[ReTestItems.JUnitTestSuite("inner-serial", ReTestItems.JUnitCounts(nothing, 0.0, 1, 0, 0, 0), ReTestItems.JUnitTestCase[ReTestItems.JUnitTestCase("inner-serial", ReTestItems.JUnitCounts(nothing, 0.0, 1, 0, 0, 0), nothing, nothing, nothing)])]), Dict("inner-serial" => 2))

shell> head report-RAITest-20230623-163847.xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites timestamp="" time="0.0" tests="1" skipped="0" failures="0" errors="0">
<testsuite name="inner-serial" timestamp="" time="0.0" tests="1" skipped="0" failures="0" errors="0">
        <testcase name="inner-serial" timestamp="" time="0.0" tests="1" skipped="0" failures="0" errors="0">
        </testcase>
</testsuite>
</testsuites>
```