### PR TITLE
Record non-distributed test results

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -405,12 +405,8 @@ function test_rel_steps(;
         end
     end
 
-    if is_distributed(parent)
-        distribute_test(parent) do
-            return _test_rel_steps(; steps, name, nested=true, clone_db, user_engine=engine)
-        end
-    else
-        _test_rel_steps(; steps, name, clone_db, user_engine=engine)
+    distribute_test(parent) do
+        return _test_rel_steps(; steps, name, nested=is_distributed(parent), clone_db, user_engine=engine)
     end
 end
 

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -120,12 +120,10 @@ function finish(ts::RAITestSet)
             for t in ts.distributed_tests
                 record(ts, fetch(t))
             end
-            # record(parent_ts, ts)
             # Record the time manually so it's available for JUnit reporting
             ts.dts.time_end = time()
             return nothing
         end
-        @debug "record" parent_ts.dts.description ts.dts.description
         record(parent_ts, ts)
         return ts
     end
@@ -222,7 +220,6 @@ function finish(ts::TestRelTestSet)
     if Test.get_testset_depth() > 0
         # Attach this test set to the parent test set
         parent_ts = Test.get_testset()
-        @debug "record" parent_ts.dts.description ts.dts.description
         record(parent_ts, ts)
         return ts
     end

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -62,7 +62,8 @@ function distribute_test(f, ts::RAITestSet)
         ref = Threads.@spawn f()
         return push!(ts.distributed_tests, ref)
     else
-        f()
+        res = f()
+        record(ts, res)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,29 @@
 using RAITest
+using RAITest: TestRelTestSet
 using Test
 
-@testset "RAITest.jl" begin
-    # Write your tests here.
+# Test that results get recorded as expected.
+for distributed in (true, false)
+    ts = @testset RAITestSet "outer" distributed=distributed begin
+        @testset "middle" begin
+            @testset TestRelTestSet "inner" begin
+                @test (sleep(1); true)
+            end
+        end
+    end
+    @testset "record (distributed=$distributed)" begin
+        outer = ts.dts
+        @test outer.description == "outer"
+        @test 1 < outer.time_end - outer.time_start < 2
+        @test length(outer.results) == 1
+        middle = only(outer.results)
+        @test middle.description == "middle"
+        @test 1 < middle.time_end - middle.time_start < 2
+        @test length(middle.results) == 1
+        inner = only(middle.results)
+        @test inner.description == "inner"
+        @test 1 < inner.time_end - inner.time_start < 2
+        @test isempty(inner.results)
+        @test inner.n_passed == 1
+    end
 end


### PR DESCRIPTION
Correctly `record` test results when `distributed=false`. 