### PR TITLE
fix: add fallback for `distribute_test` if there's no parent testset

### DIFF
--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -67,7 +67,7 @@ function distribute_test(f, ts::RAITestSet)
 end
 
 # fall back
-function distribute_test(f, ts::Test.AbstractString) = f()
+distribute_test(f, ts::Test.AbstractString) = f()
 
 function record(ts::RAITestSet, child::RAITestSet)
     junit_record!(ts.junit, child.junit)

--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -66,6 +66,9 @@ function distribute_test(f, ts::RAITestSet)
     end
 end
 
+# fall back
+function distribute_test(f, ts::Test.AbstractString) = f()
+
 function record(ts::RAITestSet, child::RAITestSet)
     junit_record!(ts.junit, child.junit)
     return record(ts.dts, child.dts)


### PR DESCRIPTION
If `@test_rel` is used at the root level, bad things happen right now