### PR TITLE
Documentation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Enables developers to run tests using the RelationalAI SDK for Julia.
 
-RAITest requires a configuration file to use the RAI Julia SDK. Documentation for this can be found at https://docs.relational.ai/rkgms/sdk/julia-sdk
+RAITest requires a configuration file to use the RAI Julia SDK. Documentation for this can
+be found at https://docs.relational.ai/rkgms/sdk/julia-sdk
 
 Using a user specified engine to test with
 ```
@@ -15,7 +16,8 @@ using RAITest
 )
 ```
 
-Create a pool of engines to test with. Values greater than one are useful for larger test suites with concurrent testing
+Create a pool of engines to test with. Values greater than one are useful for larger test
+suites with concurrent testing.
 
 ```
 using RAITest
@@ -32,7 +34,7 @@ resize_engine_pool(2)
 destroy_test_engines()
 ```
 
-Add existing engines to the pool.
+Add an existing engine to the test engine pool.
 
 ```
 using RAITest
@@ -54,7 +56,7 @@ resize_engine_pool(3)
 # Instead of provisioning as needed, provision in advance
 provision_all_test_engines()
 
-@testset ConcurrentTestSet "My tests" begin
+@testset RAITestSet "My tests" begin
     for i in 1:10
         query = "def output = $i ic { output = $i }"
         @test_rel(query = query, debug = true)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ suites with concurrent testing.
 ```
 using RAITest
 
-resize_test_engine_pool(2)
+resize_test_engine_pool!(2)
 
 @test_rel("def output = 1 ic {output = 1}")
 
@@ -31,7 +31,7 @@ resize_test_engine_pool(2)
     query = "def output = 1 ic {output = 1}",
 )
 
-destroy_test_engines()
+destroy_test_engines!()
 ```
 
 Add an existing engine to the test engine pool.
@@ -51,7 +51,7 @@ Run multiple tests concurrently.
 using RAITest
 using Test
 
-resize_test_engine_pool(3)
+resize_test_engine_pool!(3)
 
 # Instead of provisioning as needed, provision in advance
 provision_all_test_engines()
@@ -63,7 +63,7 @@ provision_all_test_engines()
     end
 end
 
-destroy_test_engines()
+destroy_test_engines!()
 ```
 
 Run multiple tests concurrently with a custom engine provider.
@@ -74,11 +74,11 @@ using Test
 
 # Always use `my_existing_engine_name` as the engine name. This must already be created as
 # RAITest will not create the engine itself
-set_engine_name_provider(()->"my_existing_engine_name")
+set_engine_name_provider!()->"my_existing_engine_name")
 
 # Releasing the engine does nothing. Controlling the engine use and cleanup is not handled
 # by RAITest
-set_engine_name_releaser((name::String)->return)
+set_engine_name_releaser!(name::String)->return)
 
 @testset "My tests" begin
     for i in 1:10

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ suites with concurrent testing.
 ```
 using RAITest
 
-resize_engine_pool(2)
+resize_test_engine_pool(2)
 
 @test_rel("def output = 1 ic {output = 1}")
 
@@ -51,7 +51,7 @@ Run multiple tests concurrently.
 using RAITest
 using Test
 
-resize_engine_pool(3)
+resize_test_engine_pool(3)
 
 # Instead of provisioning as needed, provision in advance
 provision_all_test_engines()
@@ -72,7 +72,12 @@ Run multiple tests concurrently with a custom engine provider.
 using RAITest
 using Test
 
-set_engine_name_provider(()->"my_custom_engine_name")
+# Always use `my_existing_engine_name` as the engine name. This must already be created as
+# RAITest will not create the engine itself
+set_engine_name_provider(()->"my_existing_engine_name")
+
+# Releasing the engine does nothing. Controlling the engine use and cleanup is not handled
+# by RAITest
 set_engine_name_releaser((name::String)->return)
 
 @testset "My tests" begin

--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -34,7 +34,7 @@ function __init__()
     try
         set_context!(Context(load_config()))
     catch
-        @warn "No `default` RAI context found. Use `set_context` to pass in a context and enable usage of `RAITest`."
+        @warn "No `default` RAI context found. Use `set_context!` to pass in a context and enable usage of `RAITest`."
     end
 end
 

--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -9,16 +9,16 @@ export test_rel, @test_rel, @testset
 export RAITestSet
 export Step, ReadQuery, WriteQuery, Install
 
-export destroy_test_engines
-export resize_test_engine_pool
+export destroy_test_engines!
+export resize_test_engine_pool!
 export provision_all_test_engines
 export add_test_engine!
 
-export set_context
+export set_context!
 
-export set_engine_name_provider
-export set_engine_name_releaser
-export set_engine_creater
+export set_engine_name_provider!
+export set_engine_name_releaser!
+export set_engine_creater!
 
 include("code-util.jl")
 
@@ -32,7 +32,7 @@ include("engines.jl")
 
 function __init__()
     try
-        set_context(Context(load_config()))
+        set_context!(Context(load_config()))
     catch
         @warn "No `default` RAI context found. Use `set_context` to pass in a context and enable usage of `RAITest`."
     end

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -1,6 +1,35 @@
 # helper for optional types
 const Option{T} = Union{Nothing, T}
 
+# Convert accepted install source types to Dict{String, String}
+convert_to_install_kv(install_dict::Dict{String, String}) = install_dict
+convert_to_install_kv(install_pair::Pair{String, String}) = Dict(install_pair)
+convert_to_install_kv(install_string::String) = convert_to_install_kv([install_string])
+function convert_to_install_kv(install_vector::Vector{String})
+    models = Dict{String, String}()
+    for i in enumerate(install_vector)
+        models["test_install" * string(i[1])] = i[2]
+    end
+    return models
+end
+
+# Build a path/key to identify an expected relation in the output
+function build_path(base::Symbol, values)
+    name = "/:"
+    if !is_special_symbol(base)
+        name = "/:output/:"
+    end
+
+    name *= string(base)
+
+    # Now determine types
+    name *= type_string(values)
+
+    return name
+end
+
+build_path(name::Any, ::Any) = string(name)
+
 # Extract relation names from the inputs and adds them to the program
 # Turns a dict of name=>vector, with names of form :othername/Type,
 # into a series of def name = list of tuples

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -80,7 +80,7 @@ set_engine_name_provider(() -> my_custom_engine_selector("MyEngine"))
 
 ```
 """
-function set_engine_name_provider(provider::Function)
+function set_engine_name_provider!(provider::Function)
     return TEST_ENGINE_PROVISION.provider = provider
 end
 
@@ -99,7 +99,7 @@ set_engine_name_releaser((::String) -> nothing)
 set_engine_name_releaser((name::String) -> delete_engine(context, name))
 ```
 """
-function set_engine_name_releaser(releaser::Function)
+function set_engine_name_releaser!(releaser::Function)
     return TEST_ENGINE_PROVISION.releaser = releaser
 end
 
@@ -114,7 +114,7 @@ Set a function used to create engines.
     set_engine_creater(create_default_engine)
 ```
 """
-function set_engine_creater(creater::Function)
+function set_engine_creater!(creater::Function)
     return TEST_ENGINE_PROVISION.creater = creater
 end
 

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -75,8 +75,8 @@ provider selects a name from a pool of available test engines.
 # Examples
 
 ```
-set_engine_name_provider(() -> "MyEngine")
-set_engine_name_provider(() -> my_custom_engine_selector())
+set_engine_name_provider!() -> "MyEngine")
+set_engine_name_provider!() -> my_custom_engine_selector())
 
 ```
 """
@@ -85,7 +85,7 @@ function set_engine_name_provider!(provider::Function)
 end
 
 """
-    set_engine_name_releaser(releaser::Function)
+    set_engine_name_releaser!(releaser::Function)
 
 Set a releaser for test engine names.
 
@@ -95,8 +95,8 @@ marks an engine in the test engine pool as available for use by another test.
 # Examples
 
 ```
-set_engine_name_releaser((::String) -> nothing)
-set_engine_name_releaser((name::String) -> delete_engine(context, name))
+set_engine_name_releaser!(::String) -> nothing)
+set_engine_name_releaser!(name::String) -> my_custom_engine_releaser(name))
 ```
 """
 function set_engine_name_releaser!(releaser::Function)
@@ -104,7 +104,7 @@ function set_engine_name_releaser!(releaser::Function)
 end
 
 """
-    set_engine_creater(creater::Function)
+    set_engine_creater!(creater::Function)
 
 Set a function used to create engines.
 

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -76,7 +76,7 @@ provider selects a name from a pool of available test engines.
 
 ```
 set_engine_name_provider(() -> "MyEngine")
-set_engine_name_provider(() -> create_default_engine("MyEngine"))
+set_engine_name_provider(() -> my_custom_engine_selector("MyEngine"))
 
 ```
 """

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -65,7 +65,7 @@ get_test_engine()::String = TEST_ENGINE_PROVISION.provider()
 release_test_engine(name::String) = TEST_ENGINE_PROVISION.releaser(name)
 
 """
-    set_engine_name_provider(provider::Function)
+    set_engine_name_provider!(provider::Function)
 
 Set a provider for test engine names.
 
@@ -111,7 +111,7 @@ Set a function used to create engines.
 # Examples
 
 ```
-    set_engine_creater(create_default_engine)
+    set_engine_creater!(create_default_engine)
 ```
 """
 function set_engine_creater!(creater::Function)

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -76,7 +76,7 @@ provider selects a name from a pool of available test engines.
 
 ```
 set_engine_name_provider(() -> "MyEngine")
-set_engine_name_provider(() -> my_custom_engine_selector("MyEngine"))
+set_engine_name_provider(() -> my_custom_engine_selector())
 
 ```
 """

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -32,7 +32,10 @@ function _wait_till_provisioned(engine_name, max_wait_time_s=600)
 end
 
 """
+    create_default_engine(name::String)
+
 Create an XS engine with default settings and the provided name.
+
 If the engine already exists, return immediately. If not, create the engine then
 return once the provisioning process is complete, or failed.
 """
@@ -61,14 +64,56 @@ get_test_engine()::String = TEST_ENGINE_PROVISION.provider()
 # Release test engine. Notifies the provider that this engine is no longer in use.
 release_test_engine(name::String) = TEST_ENGINE_PROVISION.releaser(name)
 
+"""
+    set_engine_name_provider(provider::Function)
+
+Set a provider for test engine names.
+
+The provider is called by each test to select an engine to run the test with. The default
+provider selects a name from a pool of available test engines.
+
+# Examples
+
+```
+set_engine_name_provider(() -> "MyEngine")
+set_engine_name_provider(() -> create_default_engine("MyEngine"))
+
+```
+"""
 function set_engine_name_provider(provider::Function)
     return TEST_ENGINE_PROVISION.provider = provider
 end
 
+"""
+    set_engine_name_releaser(releaser::Function)
+
+Set a releaser for test engine names.
+
+The releaser will be called after a test has been run. The default releaser
+marks an engine in the test engine pool as available for use by another test.
+
+# Examples
+
+```
+set_engine_name_releaser((::String) -> nothing)
+set_engine_name_releaser((name::String) -> delete_engine(context, name))
+```
+"""
 function set_engine_name_releaser(releaser::Function)
     return TEST_ENGINE_PROVISION.releaser = releaser
 end
 
+"""
+    set_engine_creater(creater::Function)
+
+Set a function used to create engines.
+
+# Examples
+
+```
+    set_engine_creater(create_default_engine)
+```
+"""
 function set_engine_creater(creater::Function)
     return TEST_ENGINE_PROVISION.creater = creater
 end

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -98,6 +98,8 @@ function list_test_engines()
 end
 
 """
+    add_test_engine!(name::String)
+
 Add an engine to the pool of test engines
 """
 function add_test_engine!(name::String)

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -141,9 +141,9 @@ removed from the list until the desired size is reached.
 # Example
 
 ```
-resize_test_engine_pool(5)
-resize_test_engine_pool(10, id->"RAITest-test-\$id")
-resize_test_engine_pool(0)
+resize_test_engine_pool!(5)
+resize_test_engine_pool!(10, id->"RAITest-test-\$id")
+resize_test_engine_pool!(0)
 ```
 """
 function resize_test_engine_pool!(size::Int64, generator::Option{Function}=nothing)

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -139,6 +139,7 @@ If the pool size is smaller than the current size, engines will be de-provisione
 removed from the list until the desired size is reached.
 
 # Example
+
 ```
 resize_test_engine_pool(5)
 resize_test_engine_pool(10, id->"RAITest-test-\$id")

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -146,7 +146,7 @@ resize_test_engine_pool(10, id->"RAITest-test-\$id")
 resize_test_engine_pool(0)
 ```
 """
-function resize_test_engine_pool(size::Int64, generator::Option{Function}=nothing)
+function resize_test_engine_pool!(size::Int64, generator::Option{Function}=nothing)
     if size < 0
         size = 0
     end
@@ -189,7 +189,7 @@ end
 """
 Call delete for any provisioned engines and resize the engine pool to zero.
 """
-function destroy_test_engines()
-    resize_test_engine_pool(0)
+function destroy_test_engines!()
+    resize_test_engine_pool!(0)
     @info("Destroyed all test engine: ")
 end

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -128,7 +128,7 @@ function provision_all_test_engines()
 end
 
 """
-    resize_test_engine_pool(size::Int64, generator::Option{Function}=nothing)
+    resize_test_engine_pool!(size::Int64, generator::Option{Function}=nothing)
 
 Resize the engine pool
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -6,6 +6,16 @@ using Random: MersenneTwister
 using Test
 using UUIDs
 
+# Generates a name for the given base name that makes it unique between multiple
+# processing units
+# Generated names are truncated at 63 characters. This limit is reached when the
+# base name is 28 characters long. Longer base names can be used but uniqueness
+# is not guaranteed
+function gen_safe_name(basename)
+    name = "$(basename)-$(UUIDs.uuid4(MersenneTwister()))"
+    return name[1:min(sizeof(name), 63)]
+end
+
 const TEST_CONTEXT = Ref{Option{Context}}(nothing)
 
 function get_context()
@@ -27,16 +37,6 @@ set_context(Context(RAI.load_config(fname="/Users/testing/.rai")))
 """
 function set_context(new_context::Context)
     return TEST_CONTEXT[] = new_context
-end
-
-# Generates a name for the given base name that makes it unique between multiple
-# processing units
-# Generated names are truncated at 63 characters. This limit is reached when the
-# base name is 28 characters long. Longer base names can be used but uniqueness
-# is not guaranteed
-function gen_safe_name(basename)
-    name = "$(basename)-$(UUIDs.uuid4(MersenneTwister()))"
-    return name[1:min(sizeof(name), 63)]
 end
 
 function create_test_database_name(; default_basename="test_rel")::String

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -35,7 +35,7 @@ The default intialiser will load the default RAI config from the `.rai` director
 set_context(Context(RAI.load_config(fname="/Users/testing/.rai")))
 ```
 """
-function set_context(new_context::Context)
+function set_context!(new_context::Context)
     return TEST_CONTEXT[] = new_context
 end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -126,19 +126,28 @@ const AcceptedSourceTypes =
 """
     Transaction Step used for `test_rel`
 
-    - `install::Dict{String, String}`:
-        sources to install in the database.
-
-    - `broken::Bool`: if the computed values are not currently correct (wrt the `expected`
-    results), then `broken` can be used to mark the tests as broken and prevent the test
-    from failing.
-
-    - `expected_problems::Vector}`: expected problems. The semantics of
-      `expected_problems` is that the program must contain a super set of the specified
-      errors. When `expected_problems` is `[]`, this means that errors are allowed.
-      Expected problems are defined by a code and an optional starting line number
-      e.g. `Dict(:code => "name" [, :line => <number>])`
-"""
+    - `query::String`: The query to use for the test
+    - `expected::AbstractDict`: Expected values in the form
+        `Dict("/:output/:a/Int64" => [1, 2])` or
+        `Dict(:a => p1, 2])`
+        Keys can be symbols, which are mapped to /:output/:[symbol] and type derived from the
+        values, or a type that can be converted to string and used as relation path.
+    - `expected_problems::Vector`: expected problems. The semantics of
+        `expected_problems` is that the program must contain a super set of the specified
+        error codes.
+    - `allow_unexpected::Symbol`: ignore problems with severity equal or lower than
+        specified. Accepted values are `:none`, `:warning`, `:error`.
+    - `install::Dict{String, String}`: source files to install in the database.
+    - `schema_inputs::AbstractDict`: input schema for the transaction
+    - `inputs::AbstractDict`: input data to the transaction
+    - `expect_abort::Bool`: boolean indicating if the transaction is expected to abort. If it
+        is expected to abort, but it does not, then the test fails.
+    - `timeout_sec`: an upper bound on test execution time.
+    - `broken::Bool`: if the test is not currently correct (wrt the `expected`
+        results), then `broken` can be used to mark the tests as broken and prevent the test
+        from failing.
+    - `readonly`: If true, run the query as readonly
+ """
 struct Step
     query::Option{String}
     install::Dict{String, String}

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -544,8 +544,8 @@ function wait_until_done(ctx::Context, id::AbstractString, timeout_sec::Int64)
     end
 end
 
-# Execute the test query. The transaction id will be output as soon as it is known and the
-# transaction response returned when done.
+# Execute the test query. The transaction id will be output as soon as it is known, and the
+# corresponding transaction response is returned when finished.
 function _execute_test(
     name::String,
     context::Context,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -386,7 +386,7 @@ function test_rel_steps(;
     if isnothing(name)
         name = ""
     else
-        name = name * " at "
+        name = name * " @ "  # Use `@` so it's easier to strip this info later.
     end
 
     if !isnothing(location)
@@ -394,15 +394,6 @@ function test_rel_steps(;
         resolved_location = string(path, ":", location.line)
 
         name *= resolved_location
-    end
-
-    if is_reportable(parent)
-        # make sure name is unique if reporting on it
-        name_count = get!(parent.name_dict, name, 1)
-        parent.name_dict[name] += 1
-        if name_count > 1
-            name *= " ($name_count)"
-        end
     end
 
     distribute_test(parent) do
@@ -702,7 +693,7 @@ function _test_rel_step(
         else
             @test state == "ABORTED"
         end
-        
+
         @label end_of_test
     end
 end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -23,7 +23,7 @@ function get_context()
 end
 
 """
-    set_context(new_context::Context)
+    set_context!(new_context::Context)
 
 Set the context to be used by the testing framework.
 
@@ -32,7 +32,7 @@ The default intialiser will load the default RAI config from the `.rai` director
 # Examples
 
 ```
-set_context(Context(RAI.load_config(fname="/Users/testing/.rai")))
+set_context!(Context(RAI.load_config(fname="/Users/testing/.rai")))
 ```
 """
 function set_context!(new_context::Context)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -52,20 +52,12 @@ function delete_test_database(name::String)
     return delete_database(get_context(), name; readtimeout=30)
 end
 
-"""
-    test_expected(expected::AbstractDict, results, testname::String)
-
-Given a Dict of expected relations, test if the actual results contain those relations.
-Types and contents of the relations must match. Expected results should be in the form of
-a mapping from a String or Symbol to a tuple or vector of tuples.
-
+# Given a Dict of expected relations, test if the actual results contain those relations.
+# Types and contents of the relations must match. Expected results should be in the form of
+# a mapping from a String or Symbol to a tuple or vector of tuples.
 # Examples
-
-```
-test_expected(Dict(:output => [(1, "a"), (2, "b")]), results, "letters")
-test_expected(Dict("/output/Int/String" => [(1, "a"), (2, "b")]), results, "letters")
-```
-"""
+# test_expected(Dict(:output => [(1, "a"), (2, "b")]), results, "letters")
+# test_expected(Dict("/output/Int/String" => [(1, "a"), (2, "b")]), results, "letters")
 function test_expected(expected::AbstractDict, results, testname::String)
     # No testing to do, return immediaely
     isempty(expected) && return true

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -134,7 +134,6 @@ Transaction Step used for `test_rel`
   - `allow_unexpected::Symbol`: ignore problems with severity equal or lower than
     specified. Accepted values are `:none`, `:warning`, `:error`.
   - `install::Dict{String, String}`: source files to install in the database.
-  - `schema_inputs::AbstractDict`: input schema for the transaction
   - `inputs::AbstractDict`: input data to the transaction
   - `expect_abort::Bool`: boolean indicating if the transaction is expected to abort. If it
     is expected to abort, but it does not, then the test fails.
@@ -243,7 +242,6 @@ Note that `test_rel` creates a new schema for each test.
     specified. Accepted values are `:none`, `:warning`, `:error`.
   - `include_stdlib::Bool`: boolean that specifies whether to include the stdlib
   - `install::Dict{String, String}`: source files to install in the database.
-  - `schema_inputs::AbstractDict`: input schema for the transaction
   - `inputs::AbstractDict`: input data to the transaction
   - `abort_on_error::Bool`: boolean that specifies whether to abort on any
     triggered error.

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -20,6 +20,7 @@ Set the context to be used by the testing framework.
 The default intialiser will load the default RAI config from the `.rai` directory.
 
 # Examples
+
 ```
 set_context(Context(RAI.load_config(fname="/Users/testing/.rai")))
 ```
@@ -59,7 +60,8 @@ Types and contents of the relations must match. Expected results should be in th
 a mapping from a String or Symbol to a tuple or vector of tuples.
 
 # Examples
-````
+
+```
 test_expected(Dict(:output => [(1, "a"), (2, "b")]), results, "letters")
 test_expected(Dict("/output/Int/String" => [(1, "a"), (2, "b")]), results, "letters")
 ```
@@ -126,30 +128,30 @@ const AcceptedSourceTypes =
     Union{String, Pair{String, String}, Vector{String}, Dict{String, String}}
 
 """
-    Transaction Step used for `test_rel`
+Transaction Step used for `test_rel`
 
-    - `query::String`: The query to use for the test
-    - `expected::AbstractDict`: Expected values in the form
-        `Dict("/:output/:a/Int64" => [1, 2])` or
-        `Dict(:a => p1, 2])`
-        Keys can be symbols, which are mapped to /:output/:[symbol] and type derived from the
-        values, or a type that can be converted to string and used as relation path.
-    - `expected_problems::Vector`: expected problems. The semantics of
-        `expected_problems` is that the program must contain a super set of the specified
-        error codes.
-    - `allow_unexpected::Symbol`: ignore problems with severity equal or lower than
-        specified. Accepted values are `:none`, `:warning`, `:error`.
-    - `install::Dict{String, String}`: source files to install in the database.
-    - `schema_inputs::AbstractDict`: input schema for the transaction
-    - `inputs::AbstractDict`: input data to the transaction
-    - `expect_abort::Bool`: boolean indicating if the transaction is expected to abort. If it
-        is expected to abort, but it does not, then the test fails.
-    - `timeout_sec`: an upper bound on test execution time.
-    - `broken::Bool`: if the test is not currently correct (wrt the `expected`
-        results), then `broken` can be used to mark the tests as broken and prevent the test
-        from failing.
-    - `readonly`: If true, run the query as readonly
- """
+  - `query::String`: The query to use for the test
+  - `expected::AbstractDict`: Expected values in the form
+    `Dict("/:output/:a/Int64" => [1, 2])` or
+    `Dict(:a => p1, 2])`
+    Keys can be symbols, which are mapped to /:output/:[symbol] and type derived from the
+    values, or a type that can be converted to string and used as relation path.
+  - `expected_problems::Vector`: expected problems. The semantics of
+    `expected_problems` is that the program must contain a super set of the specified
+    error codes.
+  - `allow_unexpected::Symbol`: ignore problems with severity equal or lower than
+    specified. Accepted values are `:none`, `:warning`, `:error`.
+  - `install::Dict{String, String}`: source files to install in the database.
+  - `schema_inputs::AbstractDict`: input schema for the transaction
+  - `inputs::AbstractDict`: input data to the transaction
+  - `expect_abort::Bool`: boolean indicating if the transaction is expected to abort. If it
+    is expected to abort, but it does not, then the test fails.
+  - `timeout_sec`: an upper bound on test execution time.
+  - `broken::Bool`: if the test is not currently correct (wrt the `expected`
+    results), then `broken` can be used to mark the tests as broken and prevent the test
+    from failing.
+  - `readonly`: If true, run the query as readonly
+"""
 struct Step
     query::Option{String}
     install::Dict{String, String}

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -12,6 +12,18 @@ function get_context()
     return TEST_CONTEXT[]
 end
 
+"""
+    set_context(new_context::Context)
+
+Set the context to be used by the testing framework.
+
+The default intialiser will load the default RAI config from the `.rai` directory.
+
+# Examples
+```
+set_context(Context(RAI.load_config(fname="/Users/testing/.rai")))
+```
+"""
 function set_context(new_context::Context)
     return TEST_CONTEXT[] = new_context
 end
@@ -40,10 +52,17 @@ function delete_test_database(name::String)
 end
 
 """
-    test_expected(expected::AbstractDict, results, testname)
+    test_expected(expected::AbstractDict, results, testname::String)
 
 Given a Dict of expected relations, test if the actual results contain those relations.
-Types and contents of the relations must match.
+Types and contents of the relations must match. Expected results should be in the form of
+a mapping from a String or Symbol to a tuple or vector of tuples.
+
+# Examples
+````
+test_expected(Dict(:output => [(1, "a"), (2, "b")]), results, "letters")
+test_expected(Dict("/output/Int/String" => [(1, "a"), (2, "b")]), results, "letters")
+```
 """
 function test_expected(expected::AbstractDict, results, testname::String)
     # No testing to do, return immediaely
@@ -468,6 +487,7 @@ function check_flaky(name::String, logs::Vector{LogRecord})
     end
 end
 
+# Wait until a transaction has successfully finished or a timeout is reached.
 function wait_until_done(ctx::Context, id::AbstractString, timeout_sec::Int64)
     start_time_ns = time_ns()
     delta_sec = 1
@@ -507,7 +527,8 @@ function wait_until_done(ctx::Context, id::AbstractString, timeout_sec::Int64)
     end
 end
 
-# Execute the test query. Outputs the transaction id and returns the response when done.
+# Execute the test query. The transaction id will be output as soon as it is known and the
+# transaction response returned when done.
 function _execute_test(
     name::String,
     context::Context,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ if isnothing(RAITest.get_context())
     @warn "No RAI config provided. Skipping integration tests"
 else
     try
-        resize_test_engine_pool(2, (i)->"RAITest-test-$i")
+        resize_test_engine_pool!(2, (i)->"RAITest-test-$i")
         provision_all_test_engines()
 
         @testset RAITestSet "Basic Integration" begin
@@ -57,7 +57,7 @@ else
         end
 
     finally
-        resize_test_engine_pool(0)
+        resize_test_engine_pool!(0)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,3 +27,19 @@ for distributed in (true, false)
         @test inner.n_passed == 1
     end
 end
+
+@testset "strip_location" begin
+    for line in (0, 42, 999)
+        for path in (
+            "foo-tests.jl",
+            joinpath("bar", "foo.jl"),
+            joinpath("qux", "bar", "foo.jl"),
+            joinpath("test_dir", "qux", "bar", "foo-test.jl"),
+        )
+            for name in ("name", "evil name @ looks/like/a/file.jl:123")
+                @show full_name = "$name @ $path:$line"
+                @test RAITest.strip_location(full_name) == name
+            end
+        end
+    end
+end


### PR DESCRIPTION
Add/extend documentation, particularly for exported methods. Some utility methods are moved to `code-util.jl` where they make more sense.