### PR TITLE
Use `file:line` as the name when `name` not passed

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -384,16 +384,14 @@ function test_rel_steps(;
     parent = Test.get_testset()
 
     if isnothing(name)
-        name = ""
-    else
-        name = name * " @ "  # Use `@` so it's easier to strip this info later.
+        name = isnothing(location) ? "" : string(basename(string(location.file)), ":", location.line)
     end
 
     if !isnothing(location)
         path = joinpath(splitpath(string(location.file))[max(1, end - 2):end])
         resolved_location = string(path, ":", location.line)
-
-        name *= resolved_location
+        # Use `@` so it's easier to strip this info later.
+        name = string(name, " @ ", resolved_location)
     end
 
     distribute_test(parent) do


### PR DESCRIPTION
When a `name` is not given to `@test_rel`, we will now use the filename and line number as the name, and then append the longer "@ location" information that we previously only appended to named `@test_rel`s. This makes it so that `file:line` is the "test name" in the XML report (and `path/to/file` as the "test suite"), matching our old internal `@test_rel`, which is the primary motivation for the change.

i.e. `name`-less `@test_rel` will now appear in logs with the same style as those with a `name`, e.g.
```
[ Info: [PASS] file.jl:42 @ dir1/dir2/file.jl:42  
[ Info: [PASS] name @ dir1/dir2/file.jl:99
```
whereas before they appeared with just the location info like
```
[ Info: [PASS] dir1/dir2/file.jl:42
[ Info: [PASS] name @ dir1/dir2/file.jl:99
```
