### PR TITLE
Keep existing name generator when resizing engine pool

### DIFF
--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -98,8 +98,6 @@ function list_test_engines()
 end
 
 """
-    add_test_engine!(name::String)
-
 Add an engine to the pool of test engines
 """
 function add_test_engine!(name::String)

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -126,7 +126,7 @@ function provision_all_test_engines()
 end
 
 """
-    resize_test_engine_pool(size::Int64, generator::Option{Function})
+    resize_test_engine_pool(size::Int64, generator::Option{Function}=nothing)
 
 Resize the engine pool
 

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -98,6 +98,8 @@ function list_test_engines()
 end
 
 """
+    add_test_engine!(name::String)
+
 Add an engine to the pool of test engines
 """
 function add_test_engine!(name::String)
@@ -127,20 +129,41 @@ end
 
 """
     resize_test_engine_pool(5)
-    resize_test_engine_pool(5, get_next_engine_name)
 
 Resize the engine pool using the given name generator
 
-If an name generator is given it will be passed a unique id each time it is called.
+If a name generator is given it will be passed a unique id each time it is called.
+
 If the pool size is smaller than the current size, engines will be de-provisioned and
 removed from the list until the desired size is reached.
+# Example
+```
+resize_test_engine_pool(5, id->"RAITest-test-\$id")
+```
 """
-function resize_test_engine_pool(size::Int64, generator::Function=get_next_engine_name)
+function resize_test_engine_pool(size::Int64, generator::Function)
+    TEST_ENGINE_POOL.generator = generator
+
+    resize_test_engine_pool(size)
+end
+
+"""
+    resize_test_engine_pool(5)
+
+Resize the engine pool
+
+If the pool size is smaller than the current size, engines will be de-provisioned and
+removed from the list until the desired size is reached.
+# Example
+```
+resize_test_engine_pool(5)
+resize_test_engine_pool(0)
+```
+"""
+function resize_test_engine_pool(size::Int64)
     if size < 0
         size = 0
     end
-
-    TEST_ENGINE_POOL.generator = generator
 
     @lock TEST_SERVER_LOCK begin
         engines = TEST_ENGINE_POOL.engines

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -126,41 +126,30 @@ function provision_all_test_engines()
 end
 
 """
-    resize_test_engine_pool(5)
-
-Resize the engine pool using the given name generator
-
-If a name generator is given it will be passed a unique id each time it is called.
-
-If the pool size is smaller than the current size, engines will be de-provisioned and
-removed from the list until the desired size is reached.
-# Example
-```
-resize_test_engine_pool(5, id->"RAITest-test-\$id")
-```
-"""
-function resize_test_engine_pool(size::Int64, generator::Function)
-    TEST_ENGINE_POOL.generator = generator
-
-    resize_test_engine_pool(size)
-end
-
-"""
-    resize_test_engine_pool(5)
+    resize_test_engine_pool(size::Int64, generator::Option{Function})
 
 Resize the engine pool
 
+If a name generator is given it will be used to generate all new engine names. When called
+it will be passed a unique id each time it is called.
+
 If the pool size is smaller than the current size, engines will be de-provisioned and
 removed from the list until the desired size is reached.
+
 # Example
 ```
 resize_test_engine_pool(5)
+resize_test_engine_pool(10, id->"RAITest-test-\$id")
 resize_test_engine_pool(0)
 ```
 """
-function resize_test_engine_pool(size::Int64)
+function resize_test_engine_pool(size::Int64, generator::Option{Function}=nothing)
     if size < 0
         size = 0
+    end
+
+    if !isnothing(generator)
+        TEST_ENGINE_POOL.generator = generator
     end
 
     @lock TEST_SERVER_LOCK begin


### PR DESCRIPTION
Current behaviour is to replace the existing engine name generator with the default when resize is called without specifying a generator. This PR changes this to reuse the existing generator - a less surprising behaviour. I.e.

Current
```
resize_test_engine_pool(1, my_special_naming_generator)
resize_test_engine_pool(3)
->
my_special_name-1
julia-sdk-test-2
julia-sdk-test-3
```
Glorious future
```
resize_test_engine_pool(1, my_special_naming_generator)
resize_test_engine_pool(3)
->
my_special_name-1
my_special_name-2
my_special_name-3
```
