### PR TITLE
Include relation name when logging diff from expected

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -90,24 +90,48 @@ function is_special_symbol(symbol::Symbol)::Bool
 end
 
 # Generate a string representing the Rel type for the input
-# Expected inputs are a vector of types, a tuple of types, or a type
 function type_string(input::Vector)
-    if isempty(input)
-        return ""
-    end
-    return type_string(input[1])
-end
+    type = eltype(input)
+    # []
+    type == Any && return ""
+    # Non-container type
+    type == eltype(type) && return "/$type"
+    # Strings (otherwise treated as containers by Julia)
+    type == String && return "/$type"
 
-function type_string(input::Tuple)
+    # Container type
     result = ""
-    for t in input
-        result *= type_string(t)
+    for e_type in fieldtypes(type)
+        result *= type_string(e_type)
     end
+
     return result
 end
 
-function type_string(input)
-    return "/" * string(typeof(input))
+function type_string(input::Tuple)
+    type = typeof(input)
+    result = ""
+    for e_type in fieldtypes(type)
+        result *= type_string(e_type)
+    end
+
+    return result
+end
+
+type_string(input) = "/" * string(typeof(input))
+
+function type_string(type::DataType)
+    # Strings (otherwise treated as containers by Julia)
+    type == String && return "/$type"
+    # Non-container type
+    eltype(type) == type && return "/$type"
+    # container type: presumably a Tuple
+    result = "/("
+    for e_type in fieldtypes(type)
+        result *= type_string(e_type)
+    end
+    result *= ")"
+    return result
 end
 
 function key_to_array(input::Tuple)

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -90,48 +90,24 @@ function is_special_symbol(symbol::Symbol)::Bool
 end
 
 # Generate a string representing the Rel type for the input
+# Expected inputs are a vector of types, a tuple of types, or a type
 function type_string(input::Vector)
-    type = eltype(input)
-    # []
-    type == Any && return ""
-    # Non-container type
-    type == eltype(type) && return "/$type"
-    # Strings (otherwise treated as containers by Julia)
-    type == String && return "/$type"
-
-    # Container type
-    result = ""
-    for e_type in fieldtypes(type)
-        result *= type_string(e_type)
+    if isempty(input)
+        return ""
     end
-
-    return result
+    return type_string(input[1])
 end
 
 function type_string(input::Tuple)
-    type = typeof(input)
     result = ""
-    for e_type in fieldtypes(type)
-        result *= type_string(e_type)
+    for t in input
+        result *= type_string(t)
     end
-
     return result
 end
 
-type_string(input) = "/" * string(typeof(input))
-
-function type_string(type::DataType)
-    # Strings (otherwise treated as containers by Julia)
-    type == String && return "/$type"
-    # Non-container type
-    eltype(type) == type && return "/$type"
-    # container type: presumably a Tuple
-    result = "/("
-    for e_type in fieldtypes(type)
-        result *= type_string(e_type)
-    end
-    result *= ")"
-    return result
+function type_string(input)
+    return "/" * string(typeof(input))
 end
 
 function key_to_array(input::Tuple)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -73,13 +73,10 @@ function test_expected(expected::AbstractDict, results, testname::String)
         expected_result_tuple_vector = sort(to_vector_of_tuples(e.second))
 
         # Empty results will not be in the output so check for non-presence
-        if isempty(expected_result_tuple_vector)
-            if haskey(results, name)
-                @info("$testname: Expected empty " * name * " not empty")
-                return false
-            end
+        if isempty(expected_result_tuple_vector) && !haskey(results, name)
             continue
         end
+
         if !haskey(results, name)
             @info("$testname: Expected relation $name not found")
             @debug("$testname: Results", results)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -73,10 +73,13 @@ function test_expected(expected::AbstractDict, results, testname::String)
         expected_result_tuple_vector = sort(to_vector_of_tuples(e.second))
 
         # Empty results will not be in the output so check for non-presence
-        if isempty(expected_result_tuple_vector) && !haskey(results, name)
+        if isempty(expected_result_tuple_vector)
+            if haskey(results, name)
+                @info("$testname: Expected empty " * name * " not empty")
+                return false
+            end
             continue
         end
-
         if !haskey(results, name)
             @info("$testname: Expected relation $name not found")
             @debug("$testname: Results", results)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -75,7 +75,14 @@ function test_expected(expected::AbstractDict, results, testname::String)
         # Empty results will not be in the output so check for non-presence
         if isempty(expected_result_tuple_vector)
             if haskey(results, name)
-                @info("$testname: Expected empty " * name * " not empty")
+                actual_result = results[name]
+                actual_result_vector = sort(collect(zip(actual_result...)))
+
+                @info(
+                    "$testname: Expected result vs actual for $name",
+                    expected_result_tuple_vector,
+                    actual_result_vector
+                )
                 return false
             end
             continue

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -88,9 +88,7 @@ function test_expected(expected::AbstractDict, results, testname::String)
 
         # convert actual results to a vector for comparison
         actual_result = results[name]
-
-        # true => [()], false => missing
-        actual_result_vector = isempty(actual_result) ? [()] : sort(collect(zip(actual_result...)))
+        actual_result_vector = sort(collect(zip(actual_result...)))
 
         if !isequal(expected_result_tuple_vector, actual_result_vector)
             @warn(

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -76,7 +76,11 @@ function test_expected(expected::AbstractDict, results, testname::String)
         if isempty(expected_result_tuple_vector)
             if haskey(results, name)
                 actual_result = results[name]
-                actual_result_vector = sort(collect(zip(actual_result...)))
+                if isempty(actual_result)
+                    actual_result_vector = [()]
+                else
+                    actual_result_vector = sort(collect(zip(actual_result...)))
+                end
 
                 @info(
                     "$testname: Expected result vs actual for $name",

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -88,7 +88,9 @@ function test_expected(expected::AbstractDict, results, testname::String)
 
         # convert actual results to a vector for comparison
         actual_result = results[name]
-        actual_result_vector = sort(collect(zip(actual_result...)))
+
+        # true => [()], false => missing
+        actual_result_vector = isempty(actual_result) ? [()] : sort(collect(zip(actual_result...)))
 
         if !isequal(expected_result_tuple_vector, actual_result_vector)
             @warn(

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -73,24 +73,10 @@ function test_expected(expected::AbstractDict, results, testname::String)
         expected_result_tuple_vector = sort(to_vector_of_tuples(e.second))
 
         # Empty results will not be in the output so check for non-presence
-        if isempty(expected_result_tuple_vector)
-            if haskey(results, name)
-                actual_result = results[name]
-                if isempty(actual_result)
-                    actual_result_vector = [()]
-                else
-                    actual_result_vector = sort(collect(zip(actual_result...)))
-                end
-
-                @info(
-                    "$testname: Expected result vs actual for $name",
-                    expected_result_tuple_vector,
-                    actual_result_vector
-                )
-                return false
-            end
+        if isempty(expected_result_tuple_vector) && !haskey(results, name)
             continue
         end
+
         if !haskey(results, name)
             @info("$testname: Expected relation $name not found")
             @debug("$testname: Results", results)
@@ -102,9 +88,14 @@ function test_expected(expected::AbstractDict, results, testname::String)
 
         # convert actual results to a vector for comparison
         actual_result = results[name]
-        actual_result_vector = sort(collect(zip(actual_result...)))
+        if isempty(actual_result)
+            actual_result_vector = [()]
+        else
+            actual_result_vector = sort(collect(zip(actual_result...)))
+        end
 
-        if !isequal(expected_result_tuple_vector, actual_result_vector)
+        if isempty(expected_result_tuple_vector) ||
+                !isequal(expected_result_tuple_vector, actual_result_vector)
             @warn(
                 "$testname: Expected result vs. actual for $name",
                 expected_result_tuple_vector,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -95,14 +95,14 @@ function test_expected(expected::AbstractDict, results, testname::String)
 
         if !isequal(expected_result_tuple_vector, actual_result_vector)
             @warn(
-                "$testname: Expected result vs. actual",
+                "$testname: Expected result vs. actual for $name",
                 expected_result_tuple_vector,
                 actual_result_vector
             )
             return false
         else
             @debug(
-                "$testname: Expected result vs. actual",
+                "$testname: Expected result vs. actual for $name",
                 expected_result_tuple_vector,
                 actual_result_vector
             )


### PR DESCRIPTION
If a relation shape matches the expected relation, but has different contents, we display the difference. This would be even more useful if we mentioned which relation we are displaying.