### PR TITLE
Handle single level RAITestSets

### DIFF
--- a/src/testsets.jl
+++ b/src/testsets.jl
@@ -187,7 +187,16 @@ function record(ts::RAITestSet, child::TestRelTestSet)
         nothing
     end
     tc = JUnitTestCase(name, counts, nothing, child.error_message, logs)
-    junit_record!(ts.junit, tc)
+
+    # A top level RAITestSet will contain a set of testsuites, so we need to wrap the
+    # testcase in a testsuite to record it
+    if Test.get_testset_depth() == 0
+        juts = JUnitTestSuite(ts.dts.description)
+        junit_record!(juts, tc)
+        junit_record!(ts.junit, juts)
+    else
+        junit_record!(ts.junit, tc)
+    end
     return record(ts.dts, child.dts)
 end
 record(ts::TestRelTestSet, child::AbstractTestSet) = record(ts.dts, child)


### PR DESCRIPTION
Currently this fails:
```
@testset RAITestSet "outer" begin
    @test_rel(query="def output = 1")
end
```
`@test_rel`, or `TestRelTestSet`, tries to record a `JUnitTestCase` into its parent. However, an outermost `RAITestSet` will contain `JUnitTestSuites` even if it's the only testset. An intermediate `JUnitTestSuite` is required. Determining in advance if the outermost RAITestSet will have children seems hard, so I took the approach of wrapping the testcase inside a testsuite before adding it. This also allows for children to be a mix of `@test_rel`s and `@testset`s.