### PR TITLE
Show logs for bare @test_rel runs

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -459,15 +459,17 @@ function _test_rel_steps(;
 
         return ts
     catch err
-        io, ctx = get_logging_io()
-        write(ctx, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")
+        if capture_logs
+            io, ctx = get_logging_io()
+            write(ctx, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")
 
-        # dump all of the captured logs
-        playback_log.(ctx, logger.logs)
-        Base.show(ctx, err)
-        msg = String(take!(io))
+            # dump all of the captured logs
+            playback_log.(ctx, logger.logs)
+            Base.show(ctx, err)
+            msg = String(take!(io))
 
-        @error msg database = schema engine_name = test_engine test_name = name
+            @error msg database = schema engine_name = test_engine test_name = name
+        end
     finally
         try
             delete_test_database(schema)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -468,9 +468,10 @@ function _test_rel_steps(;
             playback_log.(ctx, logger.logs)
             Base.show(ctx, err)
             msg = String(take!(io))
-
-            @error msg database = schema engine_name = test_engine test_name = name
+        else
+            msg = ""
         end
+        @error msg database = schema engine_name = test_engine test_name = name
     finally
         try
             delete_test_database(schema)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -414,8 +414,14 @@ function _test_rel_steps(;
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
     @debug("$name: using test engine: $test_engine")
 
-    logger = TestLogger(; catch_exceptions=true)
-
+    # Output logs directly if we're nested inside a concurrent RAITestSet or a standard
+    #  TestSet
+    capture_logs = nested || Test.get_testset_depth() > 0
+    if capture_logs
+        logger = TestLogger(; catch_exceptions=true)
+    else
+        logger = Base.current_logger()
+    end
     try
         stats = @timed Logging.with_logger(logger) do
             @testset TestRelTestSet nested = nested "$name" begin
@@ -432,24 +438,26 @@ function _test_rel_steps(;
         end
         duration = sprint(show, stats.time; context=:compact => true)
         ts = stats.value
-        ts.logs = logger.logs
 
-        check_flaky(name, logger.logs)
+        if capture_logs
+            ts.logs = logger.logs
+            check_flaky(name, logger.logs)
 
-        log_header = get_log_header(ts, duration, schema, test_engine)
-        if anyerror(ts) || anyfail(ts)
-            ts.error_message = log_header
-            io, ctx = get_logging_io()
-            write(ctx, log_header)
-            write(ctx, "\n\nCAPTURED LOGS:\n")
-            playback_log.(ctx, logger.logs)
-            msg = String(take!(io))
-            @error msg database = schema engine_name = test_engine
-        else
-            @info log_header
+            log_header = get_log_header(ts, duration, schema, test_engine)
+            if anyerror(ts) || anyfail(ts)
+                ts.error_message = log_header
+                io, ctx = get_logging_io()
+                write(ctx, log_header)
+                write(ctx, "\n\nCAPTURED LOGS:\n")
+                playback_log.(ctx, logger.logs)
+                msg = String(take!(io))
+                @error msg database = schema engine_name = test_engine
+            else
+                @info log_header
+            end
         end
 
-        ts
+        return ts
     catch err
         io, ctx = get_logging_io()
         write(ctx, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -395,7 +395,7 @@ function test_rel_steps(;
     end
 
     distribute_test(parent) do
-        return _test_rel_steps(; steps, name, nested=is_distributed(parent), clone_db, user_engine=engine)
+        return _test_rel_steps(; steps, name, nested=is_distributed(parent), debug, clone_db, user_engine=engine)
     end
 end
 
@@ -404,6 +404,7 @@ function _test_rel_steps(;
     steps::Vector{Step},
     name::Option{String},
     nested::Bool=false,
+    debug::Bool=false,
     clone_db::Option{String}=nothing,
     user_engine::Option{String}=nothing,
 )
@@ -445,6 +446,11 @@ function _test_rel_steps(;
             playback_log.(ctx, logger.logs)
             msg = String(take!(io))
             @error msg database = schema engine_name = test_engine
+        elseif debug || !nested
+            io, ctx = get_logging_io()
+            playback_log.(ctx, logger.logs)
+            msg = String(take!(io))
+            println(msg)
         else
             @info log_header
         end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -415,7 +415,7 @@ function _test_rel_steps(;
     @debug("$name: using test engine: $test_engine")
 
     # Output logs directly if we're nested inside a concurrent RAITestSet or a standard
-    #  TestSet
+    # TestSet
     capture_logs = nested || Test.get_testset_depth() > 0
     if capture_logs
         logger = TestLogger(; catch_exceptions=true)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -414,14 +414,8 @@ function _test_rel_steps(;
     test_engine = user_engine === nothing ? get_test_engine() : user_engine
     @debug("$name: using test engine: $test_engine")
 
-    # Output logs directly if we're nested inside a concurrent RAITestSet or a standard
-    # TestSet
-    capture_logs = nested || Test.get_testset_depth() > 0
-    if capture_logs
-        logger = TestLogger(; catch_exceptions=true)
-    else
-        logger = Base.current_logger()
-    end
+    logger = TestLogger(; catch_exceptions=true)
+
     try
         stats = @timed Logging.with_logger(logger) do
             @testset TestRelTestSet nested = nested "$name" begin
@@ -438,39 +432,33 @@ function _test_rel_steps(;
         end
         duration = sprint(show, stats.time; context=:compact => true)
         ts = stats.value
+        ts.logs = logger.logs
 
-        # If we're capturing logs then we need to make an exception to report error states
-        if capture_logs
-            ts.logs = logger.logs
-            check_flaky(name, logger.logs)
+        check_flaky(name, logger.logs)
 
-            log_header = get_log_header(ts, duration, schema, test_engine)
-            if anyerror(ts) || anyfail(ts)
-                ts.error_message = log_header
-                io, ctx = get_logging_io()
-                write(ctx, log_header)
-                write(ctx, "\n\nCAPTURED LOGS:\n")
-                playback_log.(ctx, logger.logs)
-                msg = String(take!(io))
-                @error msg database = schema engine_name = test_engine
-            else
-                @info log_header
-            end
-        end
-
-        return ts
-    catch err
-        if capture_logs
+        log_header = get_log_header(ts, duration, schema, test_engine)
+        if anyerror(ts) || anyfail(ts)
+            ts.error_message = log_header
             io, ctx = get_logging_io()
-            write(ctx, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")
-
-            # dump all of the captured logs
+            write(ctx, log_header)
+            write(ctx, "\n\nCAPTURED LOGS:\n")
             playback_log.(ctx, logger.logs)
-            Base.show(ctx, err)
             msg = String(take!(io))
+            @error msg database = schema engine_name = test_engine
         else
-            msg = ""
+            @info log_header
         end
+
+        ts
+    catch err
+        io, ctx = get_logging_io()
+        write(ctx, "[ERROR] Something went wrong running test $name \n\n CAPTURED LOGS:\n")
+
+        # dump all of the captured logs
+        playback_log.(ctx, logger.logs)
+        Base.show(ctx, err)
+        msg = String(take!(io))
+
         @error msg database = schema engine_name = test_engine test_name = name
     finally
         try

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -439,6 +439,7 @@ function _test_rel_steps(;
         duration = sprint(show, stats.time; context=:compact => true)
         ts = stats.value
 
+        # If we're capturing logs then we need to make an exception to report error states
         if capture_logs
             ts.logs = logger.logs
             check_flaky(name, logger.logs)


### PR DESCRIPTION
The log capturing currently swallows all output, only displaying any in error cases. While great as part of a long testset, displaying the log would be better if `@test_rel` is run directly.

An alternative to the approach taken might be to modify `distribute_test` to display the logs. This would be cleaner, but less immediate, thus less helpful for long-running tests. Separate nested and non-nested _test_rel_steps are also tempting alternatives.