### PR TITLE
Wait for results *and* transaction info

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -570,10 +570,6 @@ function _execute_test(
     txn_id = rsp.transaction.id
     @info "$name: Executing with txn $txn_id" transaction_id = txn_id
 
-    # The response may already contain the result. If so, we can return it immediately
-    if !isnothing(rsp.results)
-        return rsp
-    end
     # The transaction was not immediately completed.
     # Poll until the transaction is done, or times out, then return the results.
     try


### PR DESCRIPTION
Currently we return from fetching the transaction response as soon as we have results. We may not have the transaction details, though, which leads to a failure if we try to print out the reason for an abort.

This is enough to trigger the error reliably for me right now, but I suspect it is timing sensitive and not reliable:
```
@test_rel(
    query = "def output = a",
    abort_on_error = true,
    expect_abort = true,
)
```

Tests will be added in a later PR.