### PR TITLE
Add timeouts to database creation/deletion

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -32,11 +32,11 @@ function create_test_database_name(; default_basename="test_rel")::String
 end
 
 function create_test_database(name::String, clone_db::Option{String}=nothing)
-    return create_database(get_context(), name; source=clone_db).database
+    return create_database(get_context(), name; source=clone_db, readtimeout=30).database
 end
 
 function delete_test_database(name::String)
-    return delete_database(get_context(), name)
+    return delete_database(get_context(), name; readtimeout=30)
 end
 
 """


### PR DESCRIPTION
Database creation/deletion calls should return immediately, whether successful or not. There have been timeouts, however, with no logs, that could conceivably relate to database deletion and transient network issues. These are also the only network calls left that do not have a timeout. Since there is no apparent downside, and possibly a benefit, I've added read timeouts.

This PR is inspired by log-less timeouts such as https://github.com/RelationalAI/raicode/actions/runs/5668378729/job/15359135487 - there's not a lot else to be going wrong.