### PR TITLE
Fix problem indexing

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -205,10 +205,9 @@ function extract_problems(results)
         return problems
     end
 
-    indices = results[REL_CODE_KEY][1]
-    # Every diagnostic must have a code, and is indexed from 1 to length, so we use that
-    # for a key.
-    for i in indices
+    # Diagnostic categories have identical ordering so we can use row to find matches
+    # across categories, starting with row 1
+    for i in 1:length(results[REL_CODE_KEY][1])
         code = extract_detail(results, REL_CODE_KEY, 2, i)
         # index, subindex, line
         line = extract_detail(results, REL_LINE_KEY, 3, i)

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -78,7 +78,7 @@ function replace_engine(name::String)
     end
     # If the engine could not be deleted, notify and continue
     try
-        delete_engine(get_context(), name)
+        delete_engine(get_context(), name, readtimeout=30)
     catch
         @warn("Could not delete engine: ", name)
         name = TEST_ENGINE_POOL.generator(TEST_ENGINE_POOL.next_id)
@@ -174,7 +174,7 @@ function resize_test_engine_pool(size::Int64, generator::Option{Function}=nothin
         Threads.@sync for engine in engines_to_delete
             @info("Deleting engine", engine)
             @async try
-                delete_engine(get_context(), engine)
+                delete_engine(get_context(), engine, readtimeout=30)
             catch e
                 # The engine may not exist if it hasn't been used yet
                 # For other errors, we just report the error and delete what we can

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -78,7 +78,7 @@ function replace_engine(name::String)
     end
     # If the engine could not be deleted, notify and continue
     try
-        delete_engine(get_context(), name, readtimeout=30)
+        delete_engine(get_context(), name)
     catch
         @warn("Could not delete engine: ", name)
         name = TEST_ENGINE_POOL.generator(TEST_ENGINE_POOL.next_id)
@@ -174,7 +174,7 @@ function resize_test_engine_pool(size::Int64, generator::Option{Function}=nothin
         Threads.@sync for engine in engines_to_delete
             @info("Deleting engine", engine)
             @async try
-                delete_engine(get_context(), engine, readtimeout=30)
+                delete_engine(get_context(), engine)
             catch e
                 # The engine may not exist if it hasn't been used yet
                 # For other errors, we just report the error and delete what we can

--- a/test/expect_problem.jl
+++ b/test/expect_problem.jl
@@ -47,14 +47,14 @@ end
     # Test matching on code, code + line, code + line + severity
     test_results = generate_arrow([
         (
-            :index => 1,
+            :index => 2,
             :code => "UNDEFINED",
             :severity => "error",
             :line => 2,
             :message => "message",
         ),
         (
-            :index => 2,
+            :index => 3,
             :code => "UNBOUND_VARIABLE",
             :severity => "error",
             :line => 3,

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -119,6 +119,19 @@
 )
 
 @test_rel(
+    name = "Expected problems, allow none",
+    query = """
+    // Line 1
+    def output = a
+    def output = b
+    """,
+    expected_problems = [
+        (:code => :UNDEFINED, :line => 2),
+        (:code => :UNDEFINED, :line => 3)],
+    allow_unexpected = :none,
+)
+
+@test_rel(
     name = "Unexpected problem, ignore all",
     query = """
     def output = a


### PR DESCRIPTION
PR #64 broke problem indexing for some tests. The recorded index of a problem does not always correspond with the row in the returned Arrow, so we can't use it as a row index without first reordering all the rows.

Since the existing order is stable, and works, I've reverted the indexing change to continue using it.