### PR TITLE
Force load_models to finish

### DIFF
--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -78,7 +78,7 @@ function replace_engine(name::String)
     end
     # If the engine could not be deleted, notify and continue
     try
-        delete_engine(get_context(), name)
+        delete_engine(get_context(), name, readtimeout=30)
     catch
         @warn("Could not delete engine: ", name)
         name = TEST_ENGINE_POOL.generator(TEST_ENGINE_POOL.next_id)
@@ -174,7 +174,7 @@ function resize_test_engine_pool(size::Int64, generator::Option{Function}=nothin
         Threads.@sync for engine in engines_to_delete
             @info("Deleting engine", engine)
             @async try
-                delete_engine(get_context(), engine)
+                delete_engine(get_context(), engine, readtimeout=30)
             catch e
                 # The engine may not exist if it hasn't been used yet
                 # For other errors, we just report the error and delete what we can

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -624,7 +624,13 @@ function _test_rel_step(
 
     @testset TestRelTestSet "$name" broken = step.broken begin
         if !isempty(step.install)
-            load_models(get_context(), schema, engine, step.install)
+            load_models(
+                get_context(),
+                schema,
+                engine,
+                step.install;
+                readtimeout=step.timeout_sec,
+            )
         end
 
         # Don't test empty strings


### PR DESCRIPTION
In season 5 of the epic saga of adding timeouts to everything, it turns out that there was in fact one more in load_models, which hung in an unrelated PR as soon as I merged the last episode of 'adding timeouts to everything'.

We now have timeouts for database creation/deletion, engine creation/deletion, transaction execution, transaction result fetching, and model loading.