### PR TITLE
Refactor expected type determination

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -123,7 +123,8 @@ function is_special_symbol(symbol::Symbol)::Bool
     return symbol == :abort || symbol == :output || symbol == :rel
 end
 
-# Generate a string representing the Rel type for the input
+# Generate a string representing the Rel type for input Vectors
+# :a => [...]
 function type_string(input::Vector)
     type = eltype(input)
     # []
@@ -142,6 +143,8 @@ function type_string(input::Vector)
     return result
 end
 
+# Generate a string representing the Rel type for input Tuples
+# :a => (...)
 function type_string(input::Tuple)
     type = typeof(input)
     result = ""
@@ -152,8 +155,12 @@ function type_string(input::Tuple)
     return result
 end
 
+# Generate a string representing the Rel type for input values
+# :a => 1
 type_string(input) = "/" * string(typeof(input))
 
+# Generate a string representing the Rel type for input types
+# We've extracted the type from the input so now we can convert it to a String result
 function type_string(type::DataType)
     # Strings (otherwise treated as containers by Julia)
     type == String && return "/$type"

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -161,7 +161,7 @@ type_string(input) = "/" * string(typeof(input))
 
 # Generate a string representing the Rel type for input types
 # We've extracted the type from the input so now we can convert it to a String result
-function type_string(type::DataType)
+function type_string(type::Type{T}) where T
     # Strings (otherwise treated as containers by Julia)
     type == String && return "/$type"
     # Non-container type

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -125,7 +125,8 @@ function type_string(type::DataType)
     type == String && return "/$type"
     # Non-container type
     eltype(type) == type && return "/$type"
-    # container type: presumably a Tuple
+
+    # Container type: presumably a Tuple
     result = "/("
     for e_type in fieldtypes(type)
         result *= type_string(e_type)

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -90,24 +90,48 @@ function is_special_symbol(symbol::Symbol)::Bool
 end
 
 # Generate a string representing the Rel type for the input
-# Expected inputs are a vector of types, a tuple of types, or a type
 function type_string(input::Vector)
-    if isempty(input)
-        return ""
-    end
-    return type_string(input[1])
-end
+    type = eltype(input)
+    # []
+    type == Any && return ""
+    # Non-container type
+    type == eltype(type) && return "/$type"
+    # Strings (otherwise treated as containers by Julia)
+    type == String && return "/$type"
 
-function type_string(input::Tuple)
+    # Container type
     result = ""
-    for t in input
-        result *= type_string(t)
+    for e_type in fieldtypes(type)
+        result *= type_string(e_type)
     end
+
     return result
 end
 
-function type_string(input)
-    return "/" * string(typeof(input))
+function type_string(input::Tuple)
+    type = typeof(input)
+    result = ""
+    for e_type in fieldtypes(type)
+        result *= type_string(e_type)
+    end
+
+    return result
+end
+
+type_string(input) = "/" * string(typeof(input))
+
+function type_string(type::DataType)
+    # Strings (otherwise treated as containers by Julia)
+    type == String && return "/$type"
+    # Non-container type
+    eltype(type) == type && return "/$type"
+    # container type: presumably a Tuple
+    result = "/("
+    for e_type in fieldtypes(type)
+        result *= type_string(e_type)
+    end
+    result *= ")"
+    return result
 end
 
 function key_to_array(input::Tuple)

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -125,18 +125,17 @@ end
 
 # Generate a string representing the Rel type for input Vectors
 # :a => [...]
-function type_string(input::Vector)
-    type = eltype(input)
+function type_string(input::Vector{T}) where T
     # []
-    type == Any && return ""
+    T == Any && return ""
     # Non-container type
-    type == eltype(type) && return "/$type"
+    T == eltype(T) && return "/$T"
     # Strings (otherwise treated as containers by Julia)
-    type == String && return "/$type"
+    T == String && return "/$T"
 
     # Container type
     result = ""
-    for e_type in fieldtypes(type)
+    for e_type in fieldtypes(T)
         result *= type_string(e_type)
     end
 
@@ -145,10 +144,9 @@ end
 
 # Generate a string representing the Rel type for input Tuples
 # :a => (...)
-function type_string(input::Tuple)
-    type = typeof(input)
+function type_string(input::T) where { T <: Tuple}
     result = ""
-    for e_type in fieldtypes(type)
+    for e_type in fieldtypes(T)
         result *= type_string(e_type)
     end
 
@@ -157,7 +155,7 @@ end
 
 # Generate a string representing the Rel type for input values
 # :a => 1
-type_string(input) = "/" * string(typeof(input))
+type_string(input::T) where T = "/" * string(T)
 
 # Generate a string representing the Rel type for input types
 # We've extracted the type from the input so now we can convert it to a String result

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -148,6 +148,7 @@ type_string(::Type{Any}) = ""
 # :a => 1
 type_string(::Union{T, Type{T}}) where T = "/" * string(T)
 
+# The value tuple contains an inner tuple. Recurse into it.
 function type_string(::Type{T}) where { T <: Tuple }
     result = "/("
     for e_type in fieldtypes(T)

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -128,11 +128,11 @@ end
 # Vectors.
 
 # :a => [3, 4, 5]
-type_string(input::Vector{T}) where T = type_string(T)
+type_string(::Vector{T}) where T = type_string(T)
 
 # :a => [(1, 2)]
 # :a => (1, 2)
-function type_string(input::Union{T, Vector{T}}) where { T <: Tuple }
+function type_string(::Union{T, Vector{T}}) where { T <: Tuple }
     result = ""
     for e_type in fieldtypes(T)
         result *= type_string(e_type)
@@ -142,13 +142,13 @@ function type_string(input::Union{T, Vector{T}}) where { T <: Tuple }
 end
 
 # []
-type_string(input::Type{Any}) = ""
+type_string(::Type{Any}) = ""
 
 # Generate a string representing the Rel type for single values
 # :a => 1
-type_string(input::Union{T, Type{T}}) where T = "/" * string(T)
+type_string(::Union{T, Type{T}}) where T = "/" * string(T)
 
-function type_string(input::Type{T}) where { T <: Tuple }
+function type_string(::Type{T}) where { T <: Tuple }
     result = "/("
     for e_type in fieldtypes(T)
         result *= type_string(e_type)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -73,13 +73,10 @@ function test_expected(expected::AbstractDict, results, testname::String)
         expected_result_tuple_vector = sort(to_vector_of_tuples(e.second))
 
         # Empty results will not be in the output so check for non-presence
-        if isempty(expected_result_tuple_vector)
-            if haskey(results, name)
-                @info("$testname: Expected empty " * name * " not empty")
-                return false
-            end
+        if isempty(expected_result_tuple_vector) && !haskey(results, name)
             continue
         end
+
         if !haskey(results, name)
             @info("$testname: Expected relation $name not found")
             @debug("$testname: Results", results)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -88,7 +88,9 @@ function test_expected(expected::AbstractDict, results, testname::String)
 
         # convert actual results to a vector for comparison
         actual_result = results[name]
-        actual_result_vector = sort(collect(zip(actual_result...)))
+
+        # true => [()], false => missing
+        actual_result_vector = isempty(actual_result) ? [()] : sort(collect(zip(actual_result...)))
 
         if !isequal(expected_result_tuple_vector, actual_result_vector)
             @warn(

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -95,14 +95,14 @@ function test_expected(expected::AbstractDict, results, testname::String)
 
         if !isequal(expected_result_tuple_vector, actual_result_vector)
             @warn(
-                "$testname: Expected result vs. actual",
+                "$testname: Expected result vs. actual for $name",
                 expected_result_tuple_vector,
                 actual_result_vector
             )
             return false
         else
             @debug(
-                "$testname: Expected result vs. actual",
+                "$testname: Expected result vs. actual for $name",
                 expected_result_tuple_vector,
                 actual_result_vector
             )

--- a/test/expect_result.jl
+++ b/test/expect_result.jl
@@ -72,8 +72,12 @@ end
     @test RAITest.test_expected(expected, actual, "match non-existence e")
 
     expected = Dict(:a => Int64[])
+    actual = generate_arrow(Dict(:a => [Int32(1), Int32(2), Int32(3)]))
+    @test RAITest.test_expected(expected, actual, "match non-existence e 32bit")
+
+    expected = Dict(:a => Int64[])
     actual = generate_arrow(Dict(:a => ["1", "2", "3"]))
-    @test RAITest.test_expected(expected, actual, "match non-existence e S")
+    @test RAITest.test_expected(expected, actual, "match non-existence e String")
 
     expected = Dict(:a => [])
     actual = generate_arrow(Dict(:a => [()]))

--- a/test/expect_result.jl
+++ b/test/expect_result.jl
@@ -63,9 +63,25 @@ end
     actual = generate_arrow(Dict(:a => []))
     @test !RAITest.test_expected(expected, actual, "!match empty a")
 
-    expected = Dict(:a => [])
+    expected = Dict("/:output/:a/Int64" => [()])
     actual = generate_arrow(Dict(:a => [1, 2, 3]))
-    @test RAITest.test_expected(expected, actual, "!match existence e")
+    @test RAITest.test_expected(expected, actual, "match existence e")
+
+    expected = Dict("/:output/:a/Int64" => [])
+    actual = generate_arrow(Dict(:a => ["1", "2", "3"]))
+    @test RAITest.test_expected(expected, actual, "match non-existence e")
+
+    expected = Dict(:a => Int64[])
+    actual = generate_arrow(Dict(:a => ["1", "2", "3"]))
+    @test RAITest.test_expected(expected, actual, "match non-existence e S")
+
+    expected = Dict(:a => [])
+    actual = generate_arrow(Dict(:a => [()]))
+    @test !RAITest.test_expected(expected, actual, "!match non-existence e true")
+
+    expected = Dict("/:output/:a/Int64" => [])
+    actual = generate_arrow(Dict(:a => [1, 2, 3]))
+    @test !RAITest.test_expected(expected, actual, "!match non-existence e")
 
     expected = Dict(:a => [1, 2, 3])
     actual = generate_arrow(Dict(:a => [1, 2, 3], :b => []))


### PR DESCRIPTION
This PR introduces an arguable cleaner approach to determining type. This has the direct benefit of allowing determination of expected value types when no values are expected. 

Before:
```
expected = Dict(:a => Int64[])
->
"/:output/:a" => []
```
After
```
expected = Dict(:a => Int64[])
->
"/:output/:a/Int64" => []
```