### PR TITLE
Refactor test pool to be less optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,7 @@ Run multiple tests concurrently with a custom engine provider.
 using RAITest
 using Test
 
-# Always use `my_existing_engine_name` as the engine name. This must already be created as
-# RAITest will not create the engine itself
-set_engine_name_provider!()->"my_existing_engine_name")
-
-# Releasing the engine does nothing. Controlling the engine use and cleanup is not handled
-# by RAITest
-set_engine_name_releaser!(name::String)->return)
-
+set_engine_creater!((name)->create_default_engine(name, "M"))
 @testset "My tests" begin
     for i in 1:10
         query = "def output = $i ic { output = $i }"

--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -16,8 +16,6 @@ export add_test_engine!
 
 export set_context!
 
-export set_engine_name_provider!
-export set_engine_name_releaser!
 export set_engine_creater!
 
 include("code-util.jl")

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -34,7 +34,7 @@ function create_default_engine(name::String; size::String="XS")
     max_wait_time_s = 600
 
     try
-        create_engine(get_context(), name; size=size, readtimeout=max_wait_time_s)
+        create_engine(get_context(), name; size, readtimeout=max_wait_time_s)
     catch e
         # If the status code is 409 then the engine already exists and we can wait for it
         # to be ready

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -1,8 +1,3 @@
-mutable struct TestEngineProvision
-    # Create an engine. This is expected to be used by the provider as needed.
-    creater::Function
-end
-
 function _wait_till_provisioned(engine_name, max_wait_time_s=600)
     start_time = time()
     # This should be a rare event, so a coarse-grained period is acceptable

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -53,7 +53,7 @@ function create_default_engine(name::String, size::String="XS")
 end
 
 # Get test engine.
-get_test_engine()::String = get_pooled_test_engine()
+get_test_engine()::String = get_free_test_engine_name()
 
 # Release test engine. Notifies the provider that this engine is no longer in use.
 release_test_engine(name::String) = release_pooled_test_engine(name)

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -23,14 +23,14 @@ function _wait_till_provisioned(engine_name, max_wait_time_s=600)
 end
 
 """
-    create_default_engine(name::String, size::String)
+    create_default_engine(name::String; size::String)
 
-Create an XS engine with default settings and the provided name.
+Create an engine with the default configuration.
 
 If the engine already exists, return immediately. If not, create the engine then
 return once the provisioning process is complete, or failed.
 """
-function create_default_engine(name::String, size::String="XS")
+function create_default_engine(name::String; size::String="XS")
     max_wait_time_s = 600
 
     try

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -1,8 +1,4 @@
 mutable struct TestEngineProvision
-    # Returns the name of a provisioned, currently valid, engine
-    provider::Function
-    # Sends a notification that the engine represented by a string name is no longer in use
-    releaser::Function
     # Create an engine. This is expected to be used by the provider as needed.
     creater::Function
 end
@@ -32,96 +28,34 @@ function _wait_till_provisioned(engine_name, max_wait_time_s=600)
 end
 
 """
-    create_default_engine(name::String)
+    create_default_engine(name::String, size::String)
 
 Create an XS engine with default settings and the provided name.
 
 If the engine already exists, return immediately. If not, create the engine then
 return once the provisioning process is complete, or failed.
 """
-function create_default_engine(name::String)
-    size = "XS"
+function create_default_engine(name::String, size::String="XS")
     max_wait_time_s = 600
 
     try
-        get_engine(get_context(), name; readtimeout=max_wait_time_s)
-        # The engine already exists so return it immediately
-        return name
-    catch
-        # Engine does not exist yet so we'll need to create it
+        create_engine(get_context(), name; size=size, readtimeout=max_wait_time_s)
+    catch e
+        # If the status code is 409 then the engine already exists and we can wait for it
+        # to be ready
+        if e.status_code != 409
+            rethrow()
+        end
     end
-
-    # Request engine creation
-    create_engine(get_context(), name; size=size, readtimeout=max_wait_time_s)
 
     # Wait for engine to be provisioned
     return _wait_till_provisioned(name, max_wait_time_s)
 end
 
-# Get test engine. If a name is provided, the corresponding engine will be provided.
-get_test_engine()::String = TEST_ENGINE_PROVISION.provider()
+# Get test engine.
+get_test_engine()::String = get_pooled_test_engine()
 
 # Release test engine. Notifies the provider that this engine is no longer in use.
-release_test_engine(name::String) = TEST_ENGINE_PROVISION.releaser(name)
+release_test_engine(name::String) = release_pooled_test_engine(name)
 
-"""
-    set_engine_name_provider!(provider::Function)
-
-Set a provider for test engine names.
-
-The provider is called by each test to select an engine to run the test with. The default
-provider selects a name from a pool of available test engines.
-
-# Examples
-
-```
-set_engine_name_provider!() -> "MyEngine")
-set_engine_name_provider!() -> my_custom_engine_selector())
-
-```
-"""
-function set_engine_name_provider!(provider::Function)
-    return TEST_ENGINE_PROVISION.provider = provider
-end
-
-"""
-    set_engine_name_releaser!(releaser::Function)
-
-Set a releaser for test engine names.
-
-The releaser will be called after a test has been run. The default releaser
-marks an engine in the test engine pool as available for use by another test.
-
-# Examples
-
-```
-set_engine_name_releaser!(::String) -> nothing)
-set_engine_name_releaser!(name::String) -> my_custom_engine_releaser(name))
-```
-"""
-function set_engine_name_releaser!(releaser::Function)
-    return TEST_ENGINE_PROVISION.releaser = releaser
-end
-
-"""
-    set_engine_creater!(creater::Function)
-
-Set a function used to create engines.
-
-# Examples
-
-```
-    set_engine_creater!(create_default_engine)
-```
-"""
-function set_engine_creater!(creater::Function)
-    return TEST_ENGINE_PROVISION.creater = creater
-end
-
-TEST_ENGINE_POOL = TestEnginePool(Dict{String, Int64}(), 0, get_next_engine_name)
-
-TEST_ENGINE_PROVISION = TestEngineProvision(
-    get_pooled_test_engine,
-    release_pooled_test_engine,
-    create_default_engine,
-)
+TEST_ENGINE_POOL = TestEnginePool()

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -38,7 +38,7 @@ function create_default_engine(name::String; size::String="XS")
     catch e
         # If the status code is 409 then the engine already exists and we can wait for it
         # to be ready
-        if e.status_code != 409
+        if !(e isa HTTPError) || e.status_code != 409
             rethrow()
         end
     end

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -19,6 +19,8 @@ mutable struct TestEnginePool
     # This is used to enable unique, simple, naming of engines
     # Switching to randomly generated UUIDs would be needed if tests are run independently
     next_id::Int64
+    # Number of tests per engine. Values > 1 invalidate test timing, and require careful
+    # attention to engine sizing
     concurrency::Int64
     name_generator::Function
     # Create an engine. This is expected to be used by the provider as needed.

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -219,10 +219,8 @@ function _create_and_add_engines!(size::Int64)
                     # Success! Move on and try the next engine
                     continue
                 end
-                @warn("no bueno", response)
                 # The engine exists, but is not provisioned despite our best attempts
             catch e
-                @warn("very no bueno", e)
                 # The engine does not exist
             end
             # Something went wrong. Remove from the list and attempt to delete

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -14,26 +14,17 @@ end
 const TEST_SERVER_LOCK = ReentrantLock()
 const TEST_SERVER_ACQUISITION_LOCK = ReentrantLock()
 
-mutable struct TestEnginePool
-    engines::Dict{String, Int64}
+Base.@kwdef mutable struct TestEnginePool
+    engines::Dict{String, Int64} = Dict()
     # This is used to enable unique, simple, naming of engines
     # Switching to randomly generated UUIDs would be needed if tests are run independently
-    next_id::Int64
+    next_id::Int64 = 0
     # Number of tests per engine. Values > 1 invalidate test timing, and require careful
     # attention to engine sizing
-    concurrency::Int64
-    name_generator::Function
+    concurrency::Int64 = 1
+    name_generator::Function = get_next_engine_name
     # Create an engine. This is expected to be used by the provider as needed.
-    creater::Function
-end
-
-function TestEnginePool(;
-    engines::Dict{String, Int64}=Dict{String, Int64}(),
-    name_generator::Function=get_next_engine_name,
-    creater::Function=create_default_engine,
-    concurrency::Int64=1,
-)
-    return TestEnginePool(engines, 0, concurrency, name_generator, creater)
+    creater::Function = create_default_engine
 end
 
 function get_free_test_engine_name()::String

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -83,6 +83,9 @@ function replace_engine(name::String)
 
     name = TEST_ENGINE_POOL.name_generator(TEST_ENGINE_POOL.next_id)
 
+    # Provision the engine if it does not already exist.
+    TEST_ENGINE_POOL.creater(new_name)
+
     @lock TEST_SERVER_LOCK begin
         TEST_ENGINE_POOL.engines[name] = 0
     end
@@ -103,13 +106,13 @@ Add an engine to the pool of test engines. The engine will be provisioned if it 
 already.
 """
 function add_test_engine!(name::String)
+    # Provision the engine if it does not already exist.
+    TEST_ENGINE_POOL.creater(new_name)
+
     @lock TEST_SERVER_LOCK begin
         engines = TEST_ENGINE_POOL.engines
         engines[name] = 0
     end
-
-    # Provision the engine if it does not already exist.
-    TEST_ENGINE_POOL.creater(new_name)
 
     return nothing
 end

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -148,14 +148,14 @@ function resize_test_engine_pool!(size::Int64, name_generator::Option{Function}=
 
     @lock TEST_SERVER_LOCK begin
         # Add engines if size > length
-        _create_and_add_engines(size)
-        _validate_engine_pool()
+        _create_and_add_engines!(size)
+        _validate_engine_pool!()
         _trim_engine_pool!(size)
     end
 end
 
 # Test all engines and remove if they are unavailable or not successfully provisioned
-function _validate_engine_pool()
+function _validate_engine_pool!()
     @lock TEST_SERVER_LOCK begin
         @sync for engine in TEST_ENGINE_POOL.engines
             try
@@ -182,7 +182,7 @@ function _validate_engine_pool()
     end
 end
 
-function _create_and_add_engines(size::Int64)
+function _create_and_add_engines!(size::Int64)
     @lock TEST_SERVER_LOCK begin
         engines = TEST_ENGINE_POOL.engines
         increase = size - length(engines)

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -48,9 +48,6 @@ function get_free_test_engine_name()::String
         @lock TEST_SERVER_LOCK for e in TEST_ENGINE_POOL.engines
             if e.second < TEST_ENGINE_POOL.concurrency
                 TEST_ENGINE_POOL.engines[e.first] += 1
-                @info(
-                    "Acquired engine $(e.first) with $(TEST_ENGINE_POOL.engines[e.first])"
-                )
                 return e.first
             end
         end

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -159,9 +159,13 @@ function _validate_engine_pool!()
                     continue
                 end
                 # The engine exists, but is not provisioned despite our best attempts
-                @warn("$engine was not provisioned. Reported state was <$(response.state)>")
+                @warn("$engine was not provisioned. Reported state was: $(response.state)")
             catch e
-                @warn("$engine was not provisioned. Reported error was <$e>")
+                if e isa HTTPError
+                    @warn("$engine was not provisioned. Reported error was: $e")
+                else
+                    rethrow()
+                end
             end
             # Something went wrong. Remove from the list and attempt to delete
             delete!(TEST_ENGINE_POOL.engines, engine)

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -167,7 +167,7 @@ function Step(;
     expected_problems::Vector=[],
     allow_unexpected::Symbol=:warning,
     expect_abort::Bool=false,
-    timeout_sec::Int64=1800,
+    timeout_sec::Int64=300,
     readonly::Bool=false,
 )
     return Step(
@@ -271,7 +271,7 @@ function test_rel(;
     expected_problems::Vector=[],
     allow_unexpected::Symbol=:warning,
     expect_abort::Bool=false,
-    timeout_sec::Int64=1800,
+    timeout_sec::Int64=300,
     broken::Bool=false,
     clone_db::Option{String}=nothing,
     engine::Option{String}=nothing,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,6 @@ if isnothing(RAITest.get_context())
 else
     try
         resize_test_engine_pool!(2, (i)->"RAITest-test-$i")
-        provision_all_test_engines()
 
         @testset RAITestSet "Basic Integration" begin
             include("integration.jl")


### PR DESCRIPTION
The 'optional' test pool was over complicated and offered little advantage over using it directly. Functionality is almost unchanged after this refactor, but with a simpler interface.

 - set and get methods for test engine names now go directly to the engine pool.
 - Increasing the size of the engine pool also provisions the engines.
 - Getting an engine from the pool now assumes it exists.
 - The resize function grew a bit much so has been split into helpers.