### PR TITLE
[RAI-15505] Configurable default values

### DIFF
--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -345,3 +345,6 @@ function get_logging_io()
     ctx = IOContext(io, stream)
     return io, ctx
 end
+
+default_timeout() = parse(Int64, get(ENV, "TEST_REL_TEST_TIMEOUT", "300"))
+default_allowed() = Symbol(get(ENV, "TEST_REL_ALLOWED", ":warning"))

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -348,3 +348,5 @@ end
 
 default_timeout() = parse(Int64, get(ENV, "TEST_REL_TEST_TIMEOUT", "300"))
 default_allowed() = Symbol(get(ENV, "TEST_REL_ALLOWED", ":warning"))
+default_db_name() = get(ENV, "TEST_REL_DB_NAME", "test_rel")
+default_engine_name() = get(ENV, "TEST_REL_ENGINE_NAME", "test_rel")

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -347,6 +347,6 @@ function get_logging_io()
 end
 
 default_timeout() = parse(Int64, get(ENV, "TEST_REL_TEST_TIMEOUT", "300"))
-default_allowed() = Symbol(get(ENV, "TEST_REL_ALLOWED", ":warning"))
+default_allowed() = Symbol(get(ENV, "TEST_REL_ALLOWED", "warning"))
 default_db_name() = get(ENV, "TEST_REL_DB_NAME", "test_rel")
 default_engine_name() = get(ENV, "TEST_REL_ENGINE_NAME", "test_rel")

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -347,6 +347,6 @@ function get_logging_io()
 end
 
 default_timeout() = parse(Int64, get(ENV, "TEST_REL_TEST_TIMEOUT", "300"))
-default_allowed() = Symbol(get(ENV, "TEST_REL_ALLOWED", "warning"))
+default_allowed() = Symbol(get(ENV, "TEST_REL_SEVERITY_ALLOWED", "warning"))
 default_db_name() = get(ENV, "TEST_REL_DB_NAME", "test_rel")
 default_engine_name() = get(ENV, "TEST_REL_ENGINE_NAME", "test_rel")

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -132,7 +132,8 @@ function delete_test_engine!(name::String)
 end
 
 function get_next_engine_name(id::Int64)
-    return "julia-sdk-test-$(id)"
+    base_name = default_engine_name()
+    return "$(base_name)-$(id)"
 end
 
 """

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -265,7 +265,7 @@ function test_rel(;
     inputs::AbstractDict=Dict(),
     expected::AbstractDict=Dict(),
     expected_problems::Vector=[],
-    allow_unexpected::Symbol=default_timeout(),
+    allow_unexpected::Symbol=default_allowed(),
     expect_abort::Bool=false,
     timeout_sec::Int64=default_timeout(),
     broken::Bool=false,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -39,8 +39,8 @@ function set_context!(new_context::Context)
     return TEST_CONTEXT[] = new_context
 end
 
-function create_test_database_name(; default_basename="test_rel")::String
-    basename = get(ENV, "TEST_REL_DB_BASENAME", default_basename)
+function create_test_database_name()::String
+    basename = default_db_name()
     return gen_safe_name(basename)
 end
 

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -167,7 +167,7 @@ function Step(;
     expected_problems::Vector=[],
     allow_unexpected::Symbol=:warning,
     expect_abort::Bool=false,
-    timeout_sec::Int64=1800,
+    timeout_sec::Int64=300,
     readonly::Bool=false,
 )
     return Step(
@@ -271,7 +271,7 @@ function test_rel(;
     expected_problems::Vector=[],
     allow_unexpected::Symbol=:warning,
     expect_abort::Bool=false,
-    timeout_sec::Int64=1800,
+    timeout_sec::Int64=300,
     broken::Bool=false,
     clone_db::Option{String}=nothing,
     engine::Option{String}=nothing,

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -163,9 +163,9 @@ function Step(;
     inputs::AbstractDict=Dict(),
     expected::AbstractDict=Dict(),
     expected_problems::Vector=[],
-    allow_unexpected::Symbol=:warning,
+    allow_unexpected::Symbol=default_allowed(),
     expect_abort::Bool=false,
-    timeout_sec::Int64=300,
+    timeout_sec::Int64=default_timeout(),
     readonly::Bool=false,
 )
     return Step(
@@ -265,9 +265,9 @@ function test_rel(;
     inputs::AbstractDict=Dict(),
     expected::AbstractDict=Dict(),
     expected_problems::Vector=[],
-    allow_unexpected::Symbol=:warning,
+    allow_unexpected::Symbol=default_timeout(),
     expect_abort::Bool=false,
-    timeout_sec::Int64=300,
+    timeout_sec::Int64=default_timeout(),
     broken::Bool=false,
     clone_db::Option{String}=nothing,
     engine::Option{String}=nothing,


### PR DESCRIPTION
Add a configurable global default for test timeout and allow_unexpected. Update db and engine names to use a similar approach.

Engine naming now has two ways to be configured - changing the default base name (e.g. test_rel-1, test_rel-2, etc) or replacing the generator entirely (e.g. provision engine then generate a different name if there were problems).