### PR TITLE
[RAI-18577] Add ic values to ic error output

### DIFF
--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -1,6 +1,7 @@
 module RAITest
 
 using Test: @testset, TestLogger, LogRecord
+using Arrow
 
 import Logging
 import Pkg

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -7,6 +7,7 @@ const REL_SEVERITY_KEY = "/:rel/:catalog/:diagnostic/:severity/Int64/String"
 const REL_MESSAGE_KEY = "/:rel/:catalog/:diagnostic/:message/Int64/String"
 
 const IC_LINE_KEY = "/:rel/:catalog/:ic_violation/:range/:start/:line/HashValue/Int64"
+const IC_OUTPUT_KEY = "/:rel/:catalog/:ic_violation/:output/HashValue/String"
 const IC_REPORT_KEY = "/:rel/:catalog/:ic_violation/:report/HashValue/String"
 
 # Convert accepted install source types to Dict{String, String}
@@ -286,8 +287,13 @@ function extract_ics(results)
     for i in 1:length(results[IC_LINE_KEY][1])
         line = extract_detail(results, IC_LINE_KEY, 2, i)
         report = extract_detail(results, IC_REPORT_KEY, 2, i)
+        values = extract_detail(results, IC_OUTPUT_KEY, 2, i)
 
-        ic = (; line, report)
+        if isnothing(values)
+            ic = (; line, report)
+        else
+            ic = (; line, values, report)
+        end
         push!(ics, ic)
     end
 

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -333,7 +333,6 @@ end
 
 function extract_ics(results, limit::Int = 10)
     ics = []
-    limit = limit < 2 ? 2 : limit
 
     if !haskey(results, IC_LINE_KEY)
         return ics

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -705,7 +705,7 @@ function _test_rel_step(
                 )
             end
 
-            ics = extract_ics(results_dict)
+            ics = extract_ics(results_dict, 2)
             if !isempty(ics)
                 for ic in ics
                     @info "Integrity constraint violated: $ic"

--- a/test/ic_extraction.jl
+++ b/test/ic_extraction.jl
@@ -1,0 +1,92 @@
+using Arrow
+using Test
+
+const IC_LINE_KEY = "/:rel/:catalog/:ic_violation/:range/:start/:line/HashValue/Int64"
+const IC_OUTPUT_KEY = "/:rel/:catalog/:ic_violation/:output/HashValue"
+const IC_REPORT_KEY = "/:rel/:catalog/:ic_violation/:report/HashValue/String"
+struct HashValue
+    h1::UInt64
+    h2::UInt64
+end
+
+enumerate_row(value) = enumerate(value)
+enumerate_row(value::String) = [(1, value)]
+
+# Generate a mapping from relation id to Arrow values
+# Takes as input a Dict mapping relation symbolic name to expected values
+function generate_arrow(results)
+    arrowed_results = Dict()
+    for (name, expected) in results
+        key = RAITest.relation_id(name, expected)
+        value = []
+        if isempty(expected)
+            value = (v1=[],)
+        else
+            # Generate a v column for each column in multi-value rows
+            vs = [[] for _ in 1:length(first(expected))]
+
+            for row in expected
+                for (i, v) in enumerate_row(row)
+                    push!(vs[i], v)
+                end
+            end
+
+            ks = []
+            for i in 1:length(vs)
+                push!(ks, Symbol("v$i"))
+            end
+            value = NamedTuple{Tuple(ks)}(vs)
+        end
+        arrowed_results[key] = Arrow.Table(Arrow.tobuffer(value))
+    end
+    return arrowed_results
+end
+
+@testset "ic extraction testing" begin
+    h = (0x0000000000000001,0x0000000000000000)
+    h2 = (0x0000000000000002,0x0000000000000000)
+
+    # Basic extraction of a single row of results
+    arrow = generate_arrow(Dict(
+        IC_LINE_KEY => [(h,1)],
+        IC_OUTPUT_KEY * "/Float64/Float64" => [(h,1.0,2.0);(h,3.0,4.0)]))
+    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h) == [
+        (1.0,2.0), (3.0,4.0)
+    ]
+
+    # Extraction of mixed result types
+    arrow = generate_arrow(Dict(
+        IC_LINE_KEY => [(h,1)],
+        IC_OUTPUT_KEY * "/Int64/Int64" => [(h,1,2);(h,3,4)],
+        IC_OUTPUT_KEY * "/Float64/Float64" => [(h,1.0,2.0);(h,3.0,4.0)]))
+    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h) == [
+        (1,2), (3,4), (1.0,2.0), (3.0,4.0)
+    ]
+
+    # Sanity check that we don't extract results for a different hash
+    arrow = generate_arrow(Dict(
+        IC_LINE_KEY => [(h2,1)],
+        IC_OUTPUT_KEY * "/Int64/Int64" => [(h2,1,2);(h2,3,4)],
+        IC_OUTPUT_KEY * "/Float64/Float64" => [(h2,1.0,2.0);(h2,3.0,4.0)]))
+    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h2) == [
+        (1,2), (3,4), (1.0,2.0), (3.0,4.0)
+    ]
+
+    # Differentiate mixed hash results
+    arrow = generate_arrow(Dict(
+        IC_LINE_KEY => [(h,1),(h2,2)],
+        IC_OUTPUT_KEY * "/Int64/Int64" => [(h2,1,2);(h2,3,4)],
+        IC_OUTPUT_KEY * "/Float64/Float64" => [(h2,1.0,2.0);(h2,3.0,4.0)]))
+    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h2) == [
+        (1,2), (3,4), (1.0,2.0), (3.0,4.0)
+    ]
+
+    # Differentiate mixed hash/mixed type results
+    arrow = generate_arrow(Dict(
+        IC_LINE_KEY => [(h,1),(h2,2)],
+        IC_OUTPUT_KEY * "/Int64/Int64" => [(h,1,2);(h,3,4)],
+        IC_OUTPUT_KEY * "/Float64/Float64" => [(h2,1.0,2.0);(h2,3.0,4.0)]))
+    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h) == [
+        (1.0,2.0), (3.0,4.0)
+    ]
+end

--- a/test/ic_extraction.jl
+++ b/test/ic_extraction.jl
@@ -15,7 +15,7 @@ enumerate_row(value::String) = [(1, value)]
 # Generate a mapping from relation id to Arrow values
 # Takes as input a Dict mapping relation symbolic name to expected values
 function generate_arrow(results)
-    arrowed_results = Dict()
+    arrowed_results = Dict{String, Arrow.Table}()
     for (name, expected) in results
         key = RAITest.relation_id(name, expected)
         value = []
@@ -43,50 +43,58 @@ function generate_arrow(results)
 end
 
 @testset "ic extraction testing" begin
-    h = (0x0000000000000001,0x0000000000000000)
-    h2 = (0x0000000000000002,0x0000000000000000)
+    h = (0x0000000000000001, 0x0000000000000000)
+    h2 = (0x0000000000000002, 0x0000000000000000)
 
     # Basic extraction of a single row of results
-    arrow = generate_arrow(Dict(
-        IC_LINE_KEY => [(h,1)],
-        IC_OUTPUT_KEY * "/Float64/Float64" => [(h,1.0,2.0);(h,3.0,4.0)]))
-    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h) == [
-        (1.0,2.0), (3.0,4.0)
-    ]
+    arrow = generate_arrow(
+        Dict(
+            IC_LINE_KEY => [(h, 1)],
+            IC_OUTPUT_KEY * "/Float64/Float64" => [(h, 1.0, 2.0); (h, 3.0, 4.0)],
+        ),
+    )
+    @test RAITest.filter_ic_results(arrow, IC_OUTPUT_KEY, h) == [(1.0, 2.0), (3.0, 4.0)]
 
     # Extraction of mixed result types
-    arrow = generate_arrow(Dict(
-        IC_LINE_KEY => [(h,1)],
-        IC_OUTPUT_KEY * "/Int64/Int64" => [(h,1,2);(h,3,4)],
-        IC_OUTPUT_KEY * "/Float64/Float64" => [(h,1.0,2.0);(h,3.0,4.0)]))
-    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h) == [
-        (1,2), (3,4), (1.0,2.0), (3.0,4.0)
-    ]
+    arrow = generate_arrow(
+        Dict(
+            IC_LINE_KEY => [(h, 1)],
+            IC_OUTPUT_KEY * "/Int64/Int64" => [(h, 1, 2); (h, 3, 4)],
+            IC_OUTPUT_KEY * "/Float64/Float64" => [(h, 1.0, 2.0); (h, 3.0, 4.0)],
+        ),
+    )
+    @test RAITest.filter_ic_results(arrow, IC_OUTPUT_KEY, h) ==
+          [(1, 2), (3, 4), (1.0, 2.0), (3.0, 4.0)]
 
     # Sanity check that we don't extract results for a different hash
-    arrow = generate_arrow(Dict(
-        IC_LINE_KEY => [(h2,1)],
-        IC_OUTPUT_KEY * "/Int64/Int64" => [(h2,1,2);(h2,3,4)],
-        IC_OUTPUT_KEY * "/Float64/Float64" => [(h2,1.0,2.0);(h2,3.0,4.0)]))
-    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h2) == [
-        (1,2), (3,4), (1.0,2.0), (3.0,4.0)
-    ]
+    arrow = generate_arrow(
+        Dict(
+            IC_LINE_KEY => [(h2, 1)],
+            IC_OUTPUT_KEY * "/Int64/Int64" => [(h2, 1, 2); (h2, 3, 4)],
+            IC_OUTPUT_KEY * "/Float64/Float64" => [(h2, 1.0, 2.0); (h2, 3.0, 4.0)],
+        ),
+    )
+    @test RAITest.filter_ic_results(arrow, IC_OUTPUT_KEY, h2) ==
+          [(1, 2), (3, 4), (1.0, 2.0), (3.0, 4.0)]
 
     # Differentiate mixed hash results
-    arrow = generate_arrow(Dict(
-        IC_LINE_KEY => [(h,1),(h2,2)],
-        IC_OUTPUT_KEY * "/Int64/Int64" => [(h2,1,2);(h2,3,4)],
-        IC_OUTPUT_KEY * "/Float64/Float64" => [(h2,1.0,2.0);(h2,3.0,4.0)]))
-    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h2) == [
-        (1,2), (3,4), (1.0,2.0), (3.0,4.0)
-    ]
+    arrow = generate_arrow(
+        Dict(
+            IC_LINE_KEY => [(h, 1), (h2, 2)],
+            IC_OUTPUT_KEY * "/Int64/Int64" => [(h2, 1, 2); (h2, 3, 4)],
+            IC_OUTPUT_KEY * "/Float64/Float64" => [(h2, 1.0, 2.0); (h2, 3.0, 4.0)],
+        ),
+    )
+    @test RAITest.filter_ic_results(arrow, IC_OUTPUT_KEY, h2) ==
+          [(1, 2), (3, 4), (1.0, 2.0), (3.0, 4.0)]
 
     # Differentiate mixed hash/mixed type results
-    arrow = generate_arrow(Dict(
-        IC_LINE_KEY => [(h,1),(h2,2)],
-        IC_OUTPUT_KEY * "/Int64/Int64" => [(h,1,2);(h,3,4)],
-        IC_OUTPUT_KEY * "/Float64/Float64" => [(h2,1.0,2.0);(h2,3.0,4.0)]))
-    @test RAITest.extract_ic_results(arrow, IC_OUTPUT_KEY, h) == [
-        (1.0,2.0), (3.0,4.0)
-    ]
+    arrow = generate_arrow(
+        Dict(
+            IC_LINE_KEY => [(h, 1), (h2, 2)],
+            IC_OUTPUT_KEY * "/Int64/Int64" => [(h, 1, 2); (h, 3, 4)],
+            IC_OUTPUT_KEY * "/Float64/Float64" => [(h2, 1.0, 2.0); (h2, 3.0, 4.0)],
+        ),
+    )
+    @test RAITest.filter_ic_results(arrow, IC_OUTPUT_KEY, h) == [(1.0, 2.0), (3.0, 4.0)]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,3 +63,5 @@ end
 include("expect_result.jl")
 
 include("expect_problem.jl")
+
+include("ic_extraction.jl")


### PR DESCRIPTION
```
@test_rel("""
       def bar = 1;4.0
       ic { false }
       ic foo(x) { bar(x) implies String(x) }
       """)
```
=> 
```
┌ Error: [ERROR] Something went wrong running test REPL[199]:1 @ REPL[199]:1 
│ 
│  CAPTURED LOGS:
│ ┌ Info: REPL[199]:1 @ REPL[199]:1: Executing with txn 822c5285-af11-74f7-a9a1-0a37d5486fe9
│ └   transaction_id = "822c5285-af11-74f7-a9a1-0a37d5486fe9"
│ ┌ Error: REPL[199]:1 @ REPL[199]:1: Test Failed at /Users/mmcgrane/rai-test-julia/src/testrel.jl:700
│ │   Expression: state == "COMPLETED"
│ │    Evaluated: "ABORTED" == "COMPLETED"
│ └ @ RAITest ~/src/testsets.jl:294
│ [ Info: REPL[199]:1 @ REPL[199]:1: Transaction 822c5285-af11-74f7-a9a1-0a37d5486fe9 aborted due to "integrity constraint violation"
│ [ Info: Integrity constraint violated: (line = 3, values = "1; 4.0", report = "3| ic foo(x) { bar(x) implies String(x) }\n   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n")
│ [ Info: Integrity constraint violated: (line = 2, report = "2| ic { false }\n   ^^^^^^^^^^^^\n")
│ Some tests did not pass: 2 passed, 1 failed, 0 errored, 0 broken.
│   database = "test_rel-c6fcef37-a8aa-4290-8113-450249d5e057"
│   engine_name = "test_rel-0"
│   test_name = "REPL[199]:1 @ REPL[199]:1"
└ @ RAITest ~/src/testrel.jl:479
```

There may be maaany values that made the IC fail, so the output is limited to a subset.