### PR TITLE
Add compat bound for HTTP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Arrow = "2"
 RAI = "0.2.2"
 ReTestItems = "1.4.2"
 julia = "1.8.2"
-HTTP = "~1.9"
+HTTP = "1 - 1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 RAI = "9c30249a-7e08-11ec-0e99-a323e937e79f"
@@ -18,6 +19,7 @@ Arrow = "2"
 RAI = "0.2.2"
 ReTestItems = "1.4.2"
 julia = "1.8.2"
+HTTP = "~1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Using RAITest in github actions in combination with HTTP v1.10 seems to reliably cause timeouts on the first transactions. This PR is to limit the HTTP version to 1.9 until the issue is resolved.