### PR TITLE
Add optional names to Steps

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -310,10 +310,10 @@ function test_rel(;
 
     # Perform all inserts before other tests
     if !isempty(install)
-        insert!(steps, 1, Step(; name="install", install=convert_to_install_kv(install)))
+        pushfirst!(steps, Step(; name="install", install=convert_to_install_kv(install)))
     end
     if !isempty(inputs)
-        insert!(steps, 1, Step(; name="inputs", inputs=inputs))
+        pushfirst!(steps, Step(; name="inputs", inputs=inputs))
     end
 
     debug_env = get(ENV, "JULIA_DEBUG", "")

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -650,7 +650,7 @@ function _test_rel_step(
     @debug("$name: generated program", program)
     name = if isnothing(step.name)
         step_postfix = steps_length > 1 ? " - step$index" : ""
-        "$(string(name))$step_postfix"
+        string(name, step_postfix)
     else
         step.name
     end


### PR DESCRIPTION
Add an optional name to steps.
```
@test_rel(query="def", include_stdlib=false, inputs=Dict(:a=>[1,2]))
```
=>
```
Test Summary:                   | Pass  Fail  Total   Time
REPL[2]:1 @ REPL[2]:1           |    8     1      9  39.5s
  configuration                 |    3            3  32.1s
  inputs                        |    3            3   1.4s
  REPL[2]:1 @ REPL[2]:1 - step3 |    2     1      3   4.8s```
```

```
@test_rel(steps=[
    Step(name="before-test-1", query="def insert[:a] {1}"),
    Step(name="before-test-2", query="def insert[:b] {2}"), 
    Step(query="def insert[:c] { a + a }"),
    Step(name="validation-1", query="ic () requires { c = 3 }"),
])
```
=>
```
Test Summary:                   | Pass  Fail  Total   Time
REPL[5]:1 @ REPL[5]:1           |   11     1     12  12.9s
  before-test-1                 |    3            3   1.2s
  before-test-2                 |    3            3   1.1s
  REPL[5]:1 @ REPL[5]:1 - step3 |    3            3   1.7s
  validation-1                  |    2     1      3   8.5s
```