### PR TITLE
Global setting of test_engine and clone_db

### DIFF
--- a/src/RAITest.jl
+++ b/src/RAITest.jl
@@ -15,7 +15,7 @@ export resize_test_engine_pool!
 export provision_all_test_engines
 export add_test_engine!
 
-export set_context!
+export set_context!, set_test_engine!, set_clone_db!
 
 export set_engine_creater!
 

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -116,11 +116,11 @@ end
 # Vectors.
 
 # :a => [3, 4, 5]
-type_string(::Vector{T}) where T = type_string(T)
+type_string(::Vector{T}) where {T} = type_string(T)
 
 # :a => [(1, 2)]
 # :a => (1, 2)
-function type_string(::Union{T, Vector{T}}) where { T <: Tuple }
+function type_string(::Union{T, Vector{T}}) where {T <: Tuple}
     result = ""
     for e_type in fieldtypes(T)
         result *= type_string(e_type)
@@ -134,10 +134,10 @@ type_string(::Type{Any}) = ""
 
 # Generate a string representing the Rel type for single values
 # :a => 1
-type_string(::Union{T, Type{T}}) where T = "/" * string(T)
+type_string(::Union{T, Type{T}}) where {T} = "/" * string(T)
 
 # The value tuple contains an inner tuple. Recurse into it.
-function type_string(::Type{T}) where { T <: Tuple }
+function type_string(::Type{T}) where {T <: Tuple}
     result = "/("
     for e_type in fieldtypes(T)
         result *= type_string(e_type)
@@ -288,7 +288,7 @@ end
 # Extract the IC results for a given hash
 # These are stored in the form:
 # /:rel/:catalog/:ic_violation/:xxxx/HashValue/Type[/Type]*
-function filter_ic_results(results::Dict, path::String, h, limit::Int = 10)
+function filter_ic_results(results::Dict, path::String, h, limit::Int=10)
     ics = []
 
     # Find all the rows with the given path prefix in the key
@@ -315,7 +315,7 @@ function extract_ics(results::Nothing)
     return []
 end
 
-function extract_ics(results, limit::Int = 10)
+function extract_ics(results, limit::Int=10)
     ics = []
 
     if !haskey(results, IC_LINE_KEY)

--- a/src/engines.jl
+++ b/src/engines.jl
@@ -48,7 +48,11 @@ function create_default_engine(name::String; size::String="XS")
 end
 
 # Get test engine.
-get_test_engine()::String = get_free_test_engine_name()
+get_test_engine()::String = if isnothing(get_default_test_engine())
+    get_free_test_engine_name()
+else
+    get_default_test_engine()
+end
 
 # Release test engine. Notifies the provider that this engine is no longer in use.
 release_test_engine(name::String) = release_pooled_test_engine(name)

--- a/src/testpool.jl
+++ b/src/testpool.jl
@@ -77,7 +77,7 @@ end
 function replace_engine(name::String)
     delete_test_engine!(name)
     new_name = TEST_ENGINE_POOL.name_generator(_get_new_id())
-    add_test_engine!(new_name)
+    return add_test_engine!(new_name)
 end
 
 function list_test_engines()
@@ -168,7 +168,7 @@ function resize_test_engine_pool!(size::Int64, name_generator::Option{Function}=
     _create_and_add_engines!(size)
     _validate_engine_pool!()
     # Remove engines if size < length
-    _trim_engine_pool!(size)
+    return _trim_engine_pool!(size)
 end
 
 # Test all engines and remove if they are unavailable or not successfully provisioned

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,13 +1,18 @@
 # Basic Rel
 # --------------------------------------------------------
 
-@test_rel(name = "No input, expected, or output", query = """
-                                                  def result { 1 }
-                                                  """,)
+@test_rel(
+    name = "No input, expected, or output",
+    query = """
+    def result { 1 }
+    """,)
 
-@test_rel(name = "No input or expected, has output", query = """
-                                                     def output { 1 }
-                                                     """,)
+@test_rel(
+    name = "No input or expected, has output",
+    query = """
+    def output { 1 }
+    """,
+)
 
 @test_rel(
     name = "Input, no expected or output",
@@ -68,15 +73,23 @@
     broken = true,
 )
 
-@test_rel(name = "Expected abort", query = """
-                                   def result { 1 }
-                                   ic () requires result = 2
-                                   """, expect_abort = true,)
+@test_rel(
+    name = "Expected abort",
+    query = """
+    def result { 1 }
+    ic () requires result = 2
+    """,
+    expect_abort = true,
+)
 
-@test_rel(name = "Broken abort", query = """
-                                 def result { 1 }
-                                 ic () requires result = 2
-                                 """, broken = true,)
+@test_rel(
+    name = "Broken abort",
+    query = """
+    def result { 1 }
+    ic () requires result = 2
+    """,
+    broken = true,
+)
 
 @test_rel(
     name = "Expected problem",
@@ -126,9 +139,13 @@
     allow_unexpected = :error,
 )
 
-@test_rel(name = "Unexpected problem, broken", query = """
-                                               def output { a }
-                                               """, broken = true,)
+@test_rel(
+    name = "Unexpected problem, broken",
+    query = """
+    def output { a }
+    """,
+    broken = true,
+)
 
 @test_rel(
     name = "abort_on_error",

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,18 +1,13 @@
 # Basic Rel
 # --------------------------------------------------------
 
-@test_rel(
-    name = "No input, expected, or output",
-    query = """
-    def result { 1 }
-    """,)
+@test_rel(name = "No input, expected, or output", query = """
+                                                  def result { 1 }
+                                                  """,)
 
-@test_rel(
-    name = "No input or expected, has output",
-    query = """
-    def output { 1 }
-    """,
-)
+@test_rel(name = "No input or expected, has output", query = """
+                                                     def output { 1 }
+                                                     """,)
 
 @test_rel(
     name = "Input, no expected or output",
@@ -73,23 +68,15 @@
     broken = true,
 )
 
-@test_rel(
-    name = "Expected abort",
-    query = """
-    def result { 1 }
-    ic () requires result = 2
-    """,
-    expect_abort = true,
-)
+@test_rel(name = "Expected abort", query = """
+                                   def result { 1 }
+                                   ic () requires result = 2
+                                   """, expect_abort = true,)
 
-@test_rel(
-    name = "Broken abort",
-    query = """
-    def result { 1 }
-    ic () requires result = 2
-    """,
-    broken = true,
-)
+@test_rel(name = "Broken abort", query = """
+                                 def result { 1 }
+                                 ic () requires result = 2
+                                 """, broken = true,)
 
 @test_rel(
     name = "Expected problem",
@@ -139,13 +126,9 @@
     allow_unexpected = :error,
 )
 
-@test_rel(
-    name = "Unexpected problem, broken",
-    query = """
-    def output { a }
-    """,
-    broken = true,
-)
+@test_rel(name = "Unexpected problem, broken", query = """
+                                               def output { a }
+                                               """, broken = true,)
 
 @test_rel(
     name = "abort_on_error",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ if isnothing(RAITest.get_context())
     @warn "No RAI config provided. Skipping integration tests"
 else
     try
-        resize_test_engine_pool!(2, (i)->"RAITest-test-$i")
+        resize_test_engine_pool!(2, (i) -> "RAITest-test-$i")
 
         @testset RAITestSet "Basic Integration" begin
             include("integration.jl")


### PR DESCRIPTION
This PR adds support to setting the `test_engine` and `clone_db` in a global fashion.

The idea is that we can set which engine to use for running the tests, and from which database to clone for each test. We currently can do that on a per-`@test_rel` basis, but we would like to support a way to globally define a default.

This has been tested with the package manager testing harness.

This PR also includes changes done by the `JuliaFormatter`.