### PR TITLE
fix: don't let safe names end with a `-`

### DIFF
--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -13,7 +13,11 @@ using UUIDs
 # is not guaranteed
 function gen_safe_name(basename)
     name = "$(basename)-$(UUIDs.uuid4(MersenneTwister()))"
-    return name[1:min(sizeof(name), 63)]
+    name = name[1:min(sizeof(name), 63)]
+    if last(name) == '-'
+        name = name[1:(end - 1)]
+    end
+    return name
 end
 
 mutable struct TestDefaults


### PR DESCRIPTION
Ending with a `-` is an illegal name