### PR TITLE
Revert "Implement installs without deprecated feature"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,10 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Arrow = "2"
-HTTP = "1 - 1.9"
 RAI = "0.2.2"
 ReTestItems = "1.4.2"
 julia = "1.8.2"
+HTTP = "1 - 1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -57,21 +57,6 @@ function convert_input_dict_to_string(inputs::AbstractDict)
     return program
 end
 
-function convert_install_dict_to_string(inputs::AbstractDict{String, String})
-    program = ""
-    for input in inputs
-        name = string(input.first)
-        src = input.second
-
-        program *= """
-            def delete[:rel, :catalog, :model, "$(name)"]: rel[:catalog, :model, "$(name)"]
-            def insert[:rel, :catalog, :model, "$(name)"]: raw\"""$(src)\"""
-        """
-    end
-
-    return program
-end
-
 function input_element_to_string(input)
     return repr(input)
 end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -753,20 +753,13 @@ function _test_rel_step(
 
     @testset TestRelTestSet "$name" broken = step.broken begin
         if !isempty(step.install)
-            install_query = convert_install_dict_to_string(step.install)
-
-            # Install sources
-            response = _execute_test(
-                name,
+            load_models(
                 get_context(),
                 schema,
                 engine,
-                install_query,
-                step.timeout_sec,
-                false,
+                step.install;
+                readtimeout=step.timeout_sec,
             )
-            state = response.transaction.state
-            @debug("Install query response state:", state)
         end
 
         # Don't test empty strings

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -161,15 +161,6 @@
     expect_abort = true,
 )
 
-@test_rel(
-    name = "Install",
-    query = """
-    def output { install_test }
-    """,
-    install = Dict("install_test" => "def install_test { 21 }"),
-    expected = Dict(:output => [21]),
-)
-
 # `setup` and `tags` keywords ignored
 # --------------------------------------------------------
 


### PR DESCRIPTION
Reverts RelationalAI/rai-test-julia#93 because this change is not essential and it breaks the PR https://github.com/RelationalAI/raicode/pull/25848, in particular , the QE's distributed tests. I'll try to come back to it in due course.