### PR TITLE
Revert "Revert "Implement installs without deprecated feature""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,10 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Arrow = "2"
+HTTP = "1 - 1.9"
 RAI = "0.2.2"
 ReTestItems = "1.4.2"
 julia = "1.8.2"
-HTTP = "1 - 1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/code-util.jl
+++ b/src/code-util.jl
@@ -57,6 +57,21 @@ function convert_input_dict_to_string(inputs::AbstractDict)
     return program
 end
 
+function convert_install_dict_to_string(inputs::AbstractDict{String, String})
+    program = ""
+    for input in inputs
+        name = string(input.first)
+        src = input.second
+
+        program *= """
+            def delete[:rel, :catalog, :model, "$(name)"]: rel[:catalog, :model, "$(name)"]
+            def insert[:rel, :catalog, :model, "$(name)"]: raw\"""$(src)\"""
+        """
+    end
+
+    return program
+end
+
 function input_element_to_string(input)
     return repr(input)
 end

--- a/src/testrel.jl
+++ b/src/testrel.jl
@@ -753,13 +753,20 @@ function _test_rel_step(
 
     @testset TestRelTestSet "$name" broken = step.broken begin
         if !isempty(step.install)
-            load_models(
+            install_query = convert_install_dict_to_string(step.install)
+
+            # Install sources
+            response = _execute_test(
+                name,
                 get_context(),
                 schema,
                 engine,
-                step.install;
-                readtimeout=step.timeout_sec,
+                install_query,
+                step.timeout_sec,
+                false,
             )
+            state = response.transaction.state
+            @debug("Install query response state:", state)
         end
 
         # Don't test empty strings

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -161,6 +161,15 @@
     expect_abort = true,
 )
 
+@test_rel(
+    name = "Install",
+    query = """
+    def output { install_test }
+    """,
+    install = Dict("install_test" => "def install_test { 21 }"),
+    expected = Dict(:output => [21]),
+)
+
 # `setup` and `tags` keywords ignored
 # --------------------------------------------------------
 


### PR DESCRIPTION
The PR https://github.com/RelationalAI/rai-test-julia/pull/94 reverted the PR https://github.com/RelationalAI/rai-test-julia/pull/93 because a run of the QE's distributed tests on the reverted version for the RAICode PR https://github.com/RelationalAI/raicode/pull/25848 was [green](https://github.com/RelationalAI/raicode/actions/runs/18037525094) whereas all the runs on the PR https://github.com/RelationalAI/rai-test-julia/pull/93 were red. It appears this green status was a fluke and no longer reproduces on the PR https://github.com/RelationalAI/rai-test-julia/pull/94. So, reattempt https://github.com/RelationalAI/rai-test-julia/pull/93.